### PR TITLE
[Refactor] 앱 종료시 방에서 퇴장(로비)

### DIFF
--- a/alsongDalsong/ASRepository/ASRepository/Protocols/RepositoryProtocols.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Protocols/RepositoryProtocols.swift
@@ -44,7 +44,7 @@ public protocol AvatarRepositoryProtocol {
 public protocol RoomActionRepositoryProtocol: Sendable {
     func createRoom(nickname: String, avatar: URL) async throws -> String
     func joinRoom(nickname: String, avatar: URL, roomNumber: String) async throws -> Bool
-    func leaveRoom() async throws -> Bool
+    @discardableResult func leaveRoom() async throws -> Bool
     func startGame(roomNumber: String) async throws -> Bool
     func changeMode(roomNumber: String, mode: Mode) async throws -> Bool
     func changeRecordOrder(roomNumber: String) async throws -> Bool

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/MainRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/MainRepository.swift
@@ -60,6 +60,7 @@ final class MainRepository: MainRepositoryProtocol {
     }
 
     func disconnectRoom() {
+        databaseManager.removeRoomListener()
         update(\.number, with: nil)
         update(\.host, with: nil)
         update(\.players, with: nil)
@@ -72,7 +73,6 @@ final class MainRepository: MainRepositoryProtocol {
         update(\.submits, with: nil)
         update(\.records, with: nil)
         update(\.selectedRecords, with: nil)
-        databaseManager.removeRoomListener()
     }
 
     private func update<Value: Equatable>(

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/AppDelegate.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/AppDelegate.swift
@@ -15,7 +15,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 
-    func application(_: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options _: UIScene.ConnectionOptions) -> UISceneConfiguration {
+    func application(
+        _: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options _: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
     

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/AppDelegate.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/AppDelegate.swift
@@ -1,7 +1,9 @@
 import UIKit
 import FirebaseCore
 import ASContainer
+import ASLogKit
 import ASRepository
+import ASRepositoryProtocol
 import ASNetworkKit
 import ASCacheKit
 
@@ -15,6 +17,23 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options _: UIScene.ConnectionOptions) -> UISceneConfiguration {
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+    
+    func applicationWillTerminate(_ application: UIApplication) {
+        leaveRoom()
+        sleep(5)
+    }
+    
+    private func leaveRoom() {
+        let roomActionRepository = DIContainer.shared.resolve(RoomActionRepositoryProtocol.self)
+        
+        Task {
+            do {
+                try await roomActionRepository.leaveRoom()
+            } catch {
+                Logger.error(error.localizedDescription)
+            }
+        }
     }
     
     private func assembleDependencies() {


### PR DESCRIPTION
## 필수 리뷰어

## 관련 이슈

- #2 

## 완료 및 수정 내역

 - [x] 앱 종료 시 방에서 떠나도록 처리

## 테스트 방법 (선택)

## 리뷰 노트
- [applicationWillTerminate](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/applicationwillterminate(_:)) 방법과 [willTerminateNotification](https://developer.apple.com/documentation/uikit/uiapplication/willterminatenotification) 방법 두 개 중에 고민을 했습니다.
- 하나씩 다 해봤는데 willTerminateNotification을 사용하면 메소드가 정상적으로 호출되지 않는 문제가 발생했습니다.
   - [관련 블로그에 상세하게 나와있습니다](https://lyoodong.inblog.ai/ios-%EC%95%B1%EC%9D%B4-%EC%A2%85%EB%A3%8C%EB%90%98%EB%8A%94-%EC%8B%9C%EC%A0%90%EC%97%90-api-%EC%9A%94%EC%B2%AD%ED%95%98%EA%B8%B0-25631)
- 반면 applicationWillTerminate는 공식문서를 살표보니 메소드 return 전까지 5초 정도 시간을 벌 수 있는 것을 확인해서 해당 방식을 선택했습니다.
- 다만 5초안에 비동기 작업이 끝나지 않을 경우 시스템이 프로세스를 완전히 종료시켜버리기 때문에 여전히 방에 사용자가 남아있는 문제가 발생할 수도 있습니다. 🥲
- 아직 5초 안에 비동기 처리가 완료되지 못하면 어떻게 처리해야할지 좋은 방법을 찾지 못했는데 찾게되면 반영해두겠습니다.

## 스크린샷 (선택)


https://github.com/user-attachments/assets/b4bf645d-e4c8-4d71-8b5a-f050a24cad33


