### PR TITLE
[Feat] 로비 내 사용자 아바타 테두리 표시

### DIFF
--- a/alsongDalsong/ASRepository/ASRepository/Mock/PlayersMockRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Mock/PlayersMockRepository.swift
@@ -14,7 +14,11 @@ public final class PlayersMockRepository: PlayersRepositoryProtocol {
     public init() {
         playersPublisher.send(playersStub)
     }
-    
+
+    public func getMyID() -> String? {
+        Player.playerStub1.id
+    }
+
     public func getPlayers() -> AnyPublisher<[Player], Never> {
         playersPublisher
             .compactMap { $0 }

--- a/alsongDalsong/ASRepository/ASRepository/Protocols/RepositoryProtocols.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Protocols/RepositoryProtocols.swift
@@ -15,6 +15,7 @@ public protocol GameStatusRepositoryProtocol {
 }
 
 public protocol PlayersRepositoryProtocol {
+    func getMyID() -> String?
     func getPlayers() -> AnyPublisher<[Player], Never>
     func getHost() -> AnyPublisher<Player, Never>
     func isHost() -> AnyPublisher<Bool, Never>

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/PlayersRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/PlayersRepository.swift
@@ -11,10 +11,7 @@ final class PlayersRepository: PlayersRepositoryProtocol {
         self.mainRepository = mainRepository
     }
 
-    func getMyID() -> String? {
-        guard let myId = ASFirebaseAuth.myID else { return nil }
-        return myId
-    }
+    func getMyID() -> String? { ASFirebaseAuth.myID }
 
     func getPlayers() -> AnyPublisher<[Player], Never> {
         mainRepository.players

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/PlayersRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/PlayersRepository.swift
@@ -10,7 +10,12 @@ final class PlayersRepository: PlayersRepositoryProtocol {
     init(mainRepository: MainRepositoryProtocol) {
         self.mainRepository = mainRepository
     }
-    
+
+    func getMyID() -> String? {
+        guard let myId = ASFirebaseAuth.myID else { return nil }
+        return myId
+    }
+
     func getPlayers() -> AnyPublisher<[Player], Never> {
         mainRepository.players
             .receive(on: DispatchQueue.main)
@@ -25,7 +30,7 @@ final class PlayersRepository: PlayersRepositoryProtocol {
             .map { $0.count }
             .eraseToAnyPublisher()
     }
-    
+
     func getHost() -> AnyPublisher<Player, Never> {
         mainRepository.host
             .receive(on: DispatchQueue.main)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/SwiftUIComponents/ProfileView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/SwiftUIComponents/ProfileView.swift
@@ -32,6 +32,7 @@ struct AsyncImageView: View {
 struct ProfileView: View {
     let imagePublisher: (URL?) async -> Data?
     let name: String?
+    let isMyId: Bool
     let isHost: Bool
     let imageUrl: URL?
 
@@ -41,7 +42,9 @@ struct ProfileView: View {
                 .background(Color.asMint)
                 .frame(width: 75, height: 75)
                 .clipShape(Circle())
-                .overlay(Circle().stroke(Color.white, lineWidth: 5))
+                .overlay(
+                    Circle().stroke(isMyId ? Color.asYellow : Color.white, lineWidth: 5)
+                )
                 .overlay(alignment: .top) {
                     isHost ? Image(systemName: "crown.fill")
                         .foregroundStyle(.asYellow)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyView.swift
@@ -16,6 +16,7 @@ struct LobbyView: View {
                                     await viewModel.getAvatarData(url: url)
                                 },
                                 name: player.nickname,
+                                isMyId: player.id == viewModel.myId,
                                 isHost: player.id == viewModel.host?.id,
                                 imageUrl: player.avatarUrl
                             )
@@ -25,6 +26,7 @@ struct LobbyView: View {
                                     await viewModel.getAvatarData(url: url)
                                 },
                                 name: nil,
+                                isMyId: false,
                                 isHost: false,
                                 imageUrl: nil
                             )

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewModel.swift
@@ -11,6 +11,7 @@ final class LobbyViewModel: ObservableObject, @unchecked Sendable {
 
     let playerMaxCount = 4
     private(set) var roomNumber: String = ""
+    @Published var myId: String?
     @Published var players: [Player] = []
     @Published var host: Player?
     @Published var isHost: Bool = false
@@ -43,6 +44,8 @@ final class LobbyViewModel: ObservableObject, @unchecked Sendable {
     }
 
     func fetchData() {
+        self.myId = playersRepository.getMyID()
+
         playersRepository.getPlayers()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] players in


### PR DESCRIPTION
## 필수 리뷰어

- none

## 관련 이슈

- #10 

## 완료 및 수정 내역

 - [x] 로비 내 자신의 아바타 테두리를 다른 사용자와 다르게 수정

## 테스트 방법 (선택)

- 실행하여 테스트 가능합니다.

## 리뷰 노트

### player entity vs game repository

> 우선, 테두리 표시만으로 해당 아바타가 "나" 임을 확인하는데에 충분하다 생각했습니다.

자신의 아바타 테두리는 기본적으로 `ProfileView`에서 적용됩니다.
테두리 색상 처리 방법은 크게 두 가지가 있습니다.

1. 추후 확장 가능성(사용자가 자신의 테두리 색상 직접 지정)을 고려하여 `player` entity에 색상 프로퍼티 추가
2. `game repo`에서 viewModel로 `myId`를 전달하고 이를 통해 자신의 아바타면 특정 테두리(노란색) 지정

사실 1번으로 하는걸 원했습니다만... 아무래도 player entity가 여러 곳에서 사용중이기에 수정에 따른 영향이 클 것이라 생각했습니다.
**따라서, 당장에는 2번을 채택하되 추후 논의를 통해 테두리 색상에 대한 선택 기능이 추가될 때 entity를 수정하는 방식이 맞다고 판단했습니다.**

## 스크린샷 (선택)

|호스트가 플레이어일 때|게스트가 플레이어일 때|
|--|--|
| <img width="469" alt="image" src="https://github.com/user-attachments/assets/1c011d30-f90f-4af6-8000-39e0f8b1db56" />|![E95C6448-F406-43DA-9F32-7A95B1A08457_4_5005_c](https://github.com/user-attachments/assets/e45d98af-996d-4de7-8609-bec9c4a1e01a)|
