### PR TITLE
[Feat] 시간초과시 자동제출 방식 변경 및, 결과제출 화면에도 적용

### DIFF
--- a/alsongDalsong/ASMusicKit/ASMusicKit/ASMusicAPI.swift
+++ b/alsongDalsong/ASMusicKit/ASMusicKit/ASMusicAPI.swift
@@ -58,25 +58,21 @@ public struct ASMusicAPI {
                     throw ASMusicErrors(type: .search, reason: error.localizedDescription, file: #file, line: #line)
                 }
             default:
-            throw ASMusicErrors(type: .notAuthorized, reason: "", file: #file, line: #line)
+                throw ASMusicErrors(type: .notAuthorized, reason: "", file: #file, line: #line)
         }
     }
 
-    public func randomSong(from playlistId: String) async throws -> ASEntity.Music {
+    public func getSong(from songId: String) async throws -> ASEntity.Music {
         let status = await MusicAuthorization.request()
         switch status {
             case .authorized:
                 do {
-                    let request = MusicCatalogResourceRequest<MusicKit.Playlist>(matching: \.id, equalTo: MusicItemID(rawValue: playlistId))
-                    let playlistResponse = try await request.response()
-                    let playlist = playlistResponse.items.first!
+                    var request = MusicCatalogResourceRequest<MusicKit.Song>(matching: \.id, equalTo: MusicItemID(rawValue: songId))
+                    request.limit = 1
 
-                    let playlistWithTrack = try await playlist.with([.tracks])
-                    guard let tracks = playlistWithTrack.tracks else {
-                        throw ASMusicErrors(type: .playListHasNoSongs, reason: "", file: #file, line: #line)
-                    }
+                    let response = try await request.response()
 
-                    if let song = tracks.randomElement() {
+                    if let song = response.items.first {
                         return ASEntity.Music(
                             id: song.id.rawValue,
                             title: song.title,
@@ -90,7 +86,7 @@ public struct ASMusicAPI {
                     throw ASMusicErrors(type: .search, reason: "", file: #file, line: #line)
                 }
             default:
-            throw ASMusicErrors(type: .notAuthorized, reason: "", file: #file, line: #line)
+                throw ASMusicErrors(type: .notAuthorized, reason: "", file: #file, line: #line)
         }
         return ASEntity.Music(id: "nil", title: nil, artist: nil, artworkUrl: nil, previewUrl: nil, artworkBackgroundColor: nil)
     }

--- a/alsongDalsong/ASMusicKit/ASMusicKit/ASMusicAPI.swift
+++ b/alsongDalsong/ASMusicKit/ASMusicKit/ASMusicAPI.swift
@@ -83,10 +83,10 @@ public struct ASMusicAPI {
                         )
                     }
                 } catch {
-                    throw ASMusicErrors(type: .search, reason: "", file: #file, line: #line)
+                    throw ASMusicErrors(type: .search, reason: "Apple Music Catalog로 부터 음악을 가져오는 데 실패하였습니다.", file: #file, line: #line)
                 }
             default:
-                throw ASMusicErrors(type: .notAuthorized, reason: "", file: #file, line: #line)
+                throw ASMusicErrors(type: .notAuthorized, reason: "Apple Music에 인증되지 않았습니다.", file: #file, line: #line)
         }
         return ASEntity.Music(id: "nil", title: nil, artist: nil, artworkUrl: nil, previewUrl: nil, artworkBackgroundColor: nil)
     }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
@@ -133,11 +133,12 @@ final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
             throw error
         }
     }
-    
+
     @MainActor
     func randomMusic() async throws {
         do {
-            let randomSongId = try await getPlaylist().randomElement()!
+            let playlist = try await getPlaylist()
+            let randomSongId = playlist.randomElement()!
             selectedMusic = try await musicAPI.getSong(from: randomSongId)
         } catch {
             let error = ASErrors(type: .randomMusic, reason: error.localizedDescription, file: #file, line: #line)
@@ -147,13 +148,14 @@ final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
     }
     
     func getPlaylist() async throws -> [String] {
-        let playlistURL = URL(string: "https://firebasestorage.googleapis.com/v0/b/alsongdalsong-boostcamp.firebasestorage.app/o/audios%2FselectMusicRandom%2FselectMusicPlayList.txt?alt=media&token=5f4e4b74-fd32-487a-a894-b93afa1dae70")!
+        let playlistURL = URL(string: "https://firebasestorage.googleapis.com/v0/b/alsongdalsong-boostcamp.firebasestorage.app/o/audios%2FselectMusicRandom%2FselectMusicPlayList.txt?alt=media&token=04fd9f51-7848-4e35-ace9-119be842ed55")!
         guard let musicList = await dataDownloadRepository.downloadData(url: playlistURL) else {
+            print("selectMusic: Emtpy playlist")
             return []
         }
             
         let musicListString = String(data: musicList, encoding: .utf8)!
-        return musicListString.components(separatedBy: "\n")
+        return musicListString.components(separatedBy: "\n").filter { !$0.isEmpty }
     }
     
     func downloadMusic(url: URL) {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
@@ -138,7 +138,7 @@ final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
     func randomMusic() async throws {
         do {
             let playlist = try await getPlaylist()
-            let randomSongId = playlist.randomElement()!
+            guard let randomSongId = playlist.randomElement() else { return }
             selectedMusic = try await musicAPI.getSong(from: randomSongId)
         } catch {
             let error = ASErrors(type: .randomMusic, reason: error.localizedDescription, file: #file, line: #line)
@@ -148,7 +148,11 @@ final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
     }
     
     func getPlaylist() async throws -> [String] {
-        let playlistURL = URL(string: "https://firebasestorage.googleapis.com/v0/b/alsongdalsong-boostcamp.firebasestorage.app/o/audios%2FselectMusicRandom%2FselectMusicPlayList.txt?alt=media&token=04fd9f51-7848-4e35-ace9-119be842ed55")!
+        guard let playlistURL = URL(string: "https://firebasestorage.googleapis.com/v0/b/alsongdalsong-boostcamp.firebasestorage.app/o/audios%2FselectMusicRandom%2FselectMusicPlayList.txt?alt=media&token=04fd9f51-7848-4e35-ace9-119be842ed55")
+        else {
+            LogHandler.handleError("firebase로 부터 playlist url을 가져오지 못했습니다.")
+            return []
+        }
         guard let musicList = await dataDownloadRepository.downloadData(url: playlistURL) else {
             print("selectMusic: Emtpy playlist")
             return []

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
@@ -137,12 +137,23 @@ final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
     @MainActor
     func randomMusic() async throws {
         do {
-            selectedMusic = try await musicAPI.randomSong(from: "pl.u-aZb00o7uPlzMZzr")
+            let randomSongId = try await getPlaylist().randomElement()!
+            selectedMusic = try await musicAPI.getSong(from: randomSongId)
         } catch {
             let error = ASErrors(type: .randomMusic, reason: error.localizedDescription, file: #file, line: #line)
             LogHandler.handleError(error)
             throw error
         }
+    }
+    
+    func getPlaylist() async throws -> [String] {
+        let playlistURL = URL(string: "https://firebasestorage.googleapis.com/v0/b/alsongdalsong-boostcamp.firebasestorage.app/o/audios%2FselectMusicRandom%2FselectMusicPlayList.txt?alt=media&token=5f4e4b74-fd32-487a-a894-b93afa1dae70")!
+        guard let musicList = await dataDownloadRepository.downloadData(url: playlistURL) else {
+            return []
+        }
+            
+        let musicListString = String(data: musicList, encoding: .utf8)!
+        return musicListString.components(separatedBy: "\n")
     }
     
     func downloadMusic(url: URL) {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewController.swift
@@ -101,11 +101,7 @@ final class SubmitAnswerViewController: UIViewController {
     }
 
     private func pickRandomMusic() async throws {
-        do {
-            try await viewModel.randomMusic()
-        } catch {
-            throw error
-        }
+        try await viewModel.randomMusic()
     }
 
     private func submitAnswer() async throws {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewController.swift
@@ -41,7 +41,6 @@ final class SubmitAnswerViewController: UIViewController {
         musicPanel.bind(to: viewModel.$music)
         selectedMusicPanel.bind(to: viewModel.$selectedMusic)
         submitButton.bind(to: viewModel.$musicData)
-
     }
 
     private func setupUI() {
@@ -75,7 +74,7 @@ final class SubmitAnswerViewController: UIViewController {
             progressBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             progressBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             progressBar.heightAnchor.constraint(equalToConstant: 16),
-            
+
             scrollView.topAnchor.constraint(equalTo: progressBar.bottomAnchor),
             scrollView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
             scrollView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
@@ -99,6 +98,14 @@ final class SubmitAnswerViewController: UIViewController {
             buttonStack.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
             buttonStack.heightAnchor.constraint(greaterThanOrEqualToConstant: 64),
         ])
+    }
+
+    private func pickRandomMusic() async throws {
+        do {
+            try await viewModel.randomMusic()
+        } catch {
+            throw error
+        }
     }
 
     private func submitAnswer() async throws {
@@ -137,6 +144,10 @@ final class SubmitAnswerViewController: UIViewController {
         )
 
         progressBar.setCompletionHandler { [weak self] in
+            guard self?.viewModel.selectedMusic != nil else {
+                self?.showSubmitRandomMusicLoading()
+                return
+            }
             self?.showSubmitAnswerLoading()
         }
     }
@@ -154,6 +165,20 @@ extension SubmitAnswerViewController {
         ) { [weak self] error in
             self?.showFailSubmitMusic(error)
         }
+        presentAlert(alert)
+    }
+
+    private func showSubmitRandomMusicLoading() {
+        let alert = LoadingAlertController(
+            progressText: .submitMusic,
+            loadAction: { [weak self] in
+                try await self?.pickRandomMusic()
+                try await self?.submitAnswer()
+            },
+            errorCompletion: { [weak self] error in
+                self?.showFailSubmitMusic(error)
+            }
+        )
         presentAlert(alert)
     }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
@@ -128,6 +128,29 @@ final class SubmitAnswerViewModel: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @MainActor
+    func randomMusic() async throws {
+        do {
+            let playlist = try await getPlaylist()
+            let randomSongId = playlist.randomElement()!
+            selectedMusic = try await musicAPI.getSong(from: randomSongId)
+        } catch {
+            let error = ASErrors(type: .randomMusic, reason: error.localizedDescription, file: #file, line: #line)
+            LogHandler.handleError(error)
+            throw error
+        }
+    }
+
+    func getPlaylist() async throws -> [String] {
+        let playlistURL = URL(string: "https://firebasestorage.googleapis.com/v0/b/alsongdalsong-boostcamp.firebasestorage.app/o/audios%2FselectMusicRandom%2FsubmitAnswerPlayList.txt?alt=media&token=2c0c2629-ecc8-4895-b205-305c70c38ef6")!
+        guard let musicList = await dataDownloadRepository.downloadData(url: playlistURL) else {
+            return []
+        }
+
+        let musicListString = String(data: musicList, encoding: .utf8)!
+        return musicListString.components(separatedBy: "\n").filter { !$0.isEmpty }
+    }
+
     func searchMusic(text: String) async throws {
         do {
             if text.isEmpty { return }
@@ -155,7 +178,7 @@ final class SubmitAnswerViewModel: ObservableObject, @unchecked Sendable {
     func submitAnswer() async throws {
         guard let selectedMusic else { return }
         do {
-            let _ = try await submitsRepository.submitAnswer(answer: selectedMusic)
+            _ = try await submitsRepository.submitAnswer(answer: selectedMusic)
         } catch {
             let error = ASErrors(type: .submitAnswer, reason: error.localizedDescription, file: #file, line: #line)
             LogHandler.handleError(error)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
@@ -142,13 +142,14 @@ final class SubmitAnswerViewModel: ObservableObject, @unchecked Sendable {
     }
 
     func getPlaylist() async throws -> [String] {
-        let playlistURL = URL(string: "https://firebasestorage.googleapis.com/v0/b/alsongdalsong-boostcamp.firebasestorage.app/o/audios%2FselectMusicRandom%2FsubmitAnswerPlayList.txt?alt=media&token=2c0c2629-ecc8-4895-b205-305c70c38ef6")!
+        guard let playlistURL = URL(string: "https://firebasestorage.googleapis.com/v0/b/alsongdalsong-boostcamp.firebasestorage.app/o/audios%2FselectMusicRandom%2FsubmitAnswerPlayList.txt?alt=media&token=2c0c2629-ecc8-4895-b205-305c70c38ef6")
+        else { return [] }
         guard let musicList = await dataDownloadRepository.downloadData(url: playlistURL) else {
             return []
         }
 
         let musicListString = String(data: musicList, encoding: .utf8)!
-        return musicListString.components(separatedBy: "\n").filter { !$0.isEmpty }
+        return musicListString.split(separator: "\n").map { String($0) }
     }
 
     func searchMusic(text: String) async throws {


### PR DESCRIPTION
## 필수 리뷰어

## 관련 이슈

- #4 

## 완료 및 수정 내역
- [x] 파이어베이스에 (노래선택 못 했을 시에 골라질 노래, 정답선택 못 했을 시에 골라) 플레이리스트 만들어두기
- [x] 파이어베이스에 있는 플레이스트에 가져오기, String 배열로 전환후 랜덤 추출하기
- [x] ASMusicKit에 음악을 id로 요청해 가져오는 메서드 추가 
- [x] 노래 선택화면의 로직 변경 후 정답선택화면의 로직 추가하기

## 테스트 방법 (선택)
노래 선택화면, 혹은 정답 제출 화면에서 제출하지 말고 가만히 있기 
## 리뷰 노트

음악 선택 화면에서 타임아웃 시 랜덤 뮤직 선택하는 방식을 고치는 작업을 하던 중
회의 때 나온 내용으로는 음악의 정보들(음원프리뷰, 아트워크 등)을 미리 firebase에 업로드 해놓고 Music Entity에 맞게 가져오는 방식을 이야기 하였는데, 조금 비효율 적이라고 생각을 하여, AppleMusic에 노래별 등록 돼있는 고유 번호를 txt 파일에 저장하여 해당 아이디를 가져와 곡의 정보를 가져오는 방식으로 변경 하였습니다.

## 스크린샷 (선택)
