### PR TITLE
[Refactor] 허밍 녹음 파일 쌓이는 문제 해결

### DIFF
--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/ASErrors.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/ASErrors.swift
@@ -17,6 +17,7 @@ struct ASErrors: LocalizedError {
         case changeRecordOrder, navigateToLobby
         case submitMusic, searchMusicOnSelect, randomMusic
         case searchMusicOnSubmit, submitAnswer
+        case fileDelete
     }
 
     var errorDescription: String? {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/ASErrors.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/ASErrors.swift
@@ -17,7 +17,7 @@ struct ASErrors: LocalizedError {
         case changeRecordOrder, navigateToLobby
         case submitMusic, searchMusicOnSelect, randomMusic
         case searchMusicOnSubmit, submitAnswer
-        case fileDelete
+        case deleteFile
     }
 
     var errorDescription: String? {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/AudioHelper.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/AudioHelper.swift
@@ -244,6 +244,9 @@ extension AudioHelper {
             try await Task.sleep(nanoseconds: 6 * 1_000_000_000)
             let recordedData = await stopRecording()
             sendDataThrough(recorderDataSubject, recordedData ?? Data())
+            if recordedData != nil {
+                deleteFile(url: tempURL)
+            }
         } catch {
             let error = ASErrors(type: .startRecording, reason: error.localizedDescription, file: #file, line: #line)
             LogHandler.handleError(error)
@@ -275,6 +278,15 @@ extension AudioHelper {
         let key = UUID()
         return tempCacheDirectory
             .appendingPathComponent("\(key)")
+    }
+    
+    private func deleteFile(url: URL) {
+        do {
+            try FileManager.default.removeItem(at: url)
+            LogHandler.handleDebug("임시 파일 삭제 완료 \(url.path)")
+        } catch {
+            LogHandler.handleError(ASErrors(type: .fileDelete, reason: error.localizedDescription, file: #file, line: #line))
+        }
     }
 
     private func createCacheDirectory(with directory: URL) {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/AudioHelper.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/AudioHelper.swift
@@ -285,7 +285,7 @@ extension AudioHelper {
             try FileManager.default.removeItem(at: url)
             LogHandler.handleDebug("임시 파일 삭제 완료 \(url.path)")
         } catch {
-            LogHandler.handleError(ASErrors(type: .fileDelete, reason: error.localizedDescription, file: #file, line: #line))
+            LogHandler.handleError(ASErrors(type: .deleteFile, reason: error.localizedDescription, file: #file, line: #line))
         }
     }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/AudioHelper.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/AudioHelper.swift
@@ -241,7 +241,7 @@ extension AudioHelper {
             visualize()
             LogHandler.handleDebug("녹음 시작")
 
-            try await Task.sleep(nanoseconds: 6 * 1_000_000_000)
+            try await Task.sleep(for: .seconds(6))
             let recordedData = await stopRecording()
             sendDataThrough(recorderDataSubject, recordedData ?? Data())
             if recordedData != nil {


### PR DESCRIPTION
## 필수 리뷰어
@Sonny-Kor 

## 관련 이슈

- #7

## 완료 및 수정 내역

 - [x] temp 허밍 삭제
 - [x] 코드 가독성 개선

## 테스트 방법 (선택)

## 리뷰 노트
알쏭달쏭 처음 시작할 때 승재님께서 말씀해 주신 제안은 `자신의 허밍 녹음 파일`은 서버에서 가져오는게 아니라 디스크 I/O를 하는 것으로 기억이 나는데요...
이 방식대로 진행하다보니 `디스크 I/O + 분기처리` 2개의 작업이 발생하게 되더라고요.
반면에 현재 방식을 사용하고 temp 파일을 삭제해 준다면 `네트워킹`만 하면 되기 때문에 가독성을 가져가는게 훨씬 좋은 판단이라고 생각이 들어서 temp를 사용하지 않고 삭제해 주는 방식으로 결정했습니다!

그리고.. 가독성이 좋지 않은 부분은 코드 스타일을 개선해 봤습니다!



## 스크린샷 (선택)

https://github.com/user-attachments/assets/b30ac38d-52c5-4223-8da7-97b606dc98f5

+ 열심히 소리를 녹음했는데,,,, 들어가질 않았네요,,,, 정상적으로 진행됩니다. 다음부터는 녹음 시 소리 포함시켰는지 꼭 확인하겠습니다. 