### PR TITLE
[feat] 결과 화면 진행도 추가

### DIFF
--- a/alsongDalsong/ASEntity/ASEntity/Room.swift
+++ b/alsongDalsong/ASEntity/ASEntity/Room.swift
@@ -13,4 +13,5 @@ public struct Room: Codable {
     public var dueTime: Date?
     public var selectedRecords: [UInt8]?
     public var submits: [Answer]?
+    public var results: [Bool]?
 }

--- a/alsongDalsong/ASNetworkKit/ASNetworkKit/FirebaseEndpoint.swift
+++ b/alsongDalsong/ASNetworkKit/ASNetworkKit/FirebaseEndpoint.swift
@@ -28,6 +28,7 @@ public struct FirebaseEndpoint: Endpoint, Equatable {
         case changeRecordOrder
         case submitMusic
         case submitAnswer
+        case submitResult
         case resetGame
       
         public var description: String {
@@ -48,6 +49,8 @@ public struct FirebaseEndpoint: Endpoint, Equatable {
                     "/v2-submitMusic"
                 case .submitAnswer:
                     "/v2-submitAnswer"
+                case .submitResult:
+                    "/v2-submitResult"
                 case .changeRecordOrder:
                     "/changeRecordOrder"
                 case .resetGame:

--- a/alsongDalsong/ASRepository/ASRepository/ASRepositoryErrors.swift
+++ b/alsongDalsong/ASRepository/ASRepository/ASRepositoryErrors.swift
@@ -13,6 +13,7 @@ struct ASRepositoryErrors: LocalizedError {
         case uploadRecording
         case createRoom, joinRoom, leaveRoom, startGame, changeMode, changeRecordOrder, resetGame, sendRequest
         case submitAnswer
+        case submitResult
     }
 
     var errorDescription: String? {

--- a/alsongDalsong/ASRepository/ASRepository/Mock/HummingResultMockRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Mock/HummingResultMockRepository.swift
@@ -3,6 +3,16 @@ import ASRepositoryProtocol
 import Combine
 
 public final class HummingResultMockRepository: HummingResultRepositoryProtocol {
+
+    public func getResultsCount() -> AnyPublisher<Int, Never> {
+        Just(3)
+            .eraseToAnyPublisher()
+    }
+    
+    public func submitResult(isFinished: Bool) async throws -> Bool {
+        true
+    }
+    
     private let answers = [
         Answer.answerStub1,
         Answer.answerStub2,

--- a/alsongDalsong/ASRepository/ASRepository/Protocols/MainRepositoryProtocol.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Protocols/MainRepositoryProtocol.swift
@@ -15,6 +15,7 @@ public protocol MainRepositoryProtocol {
     var answers: CurrentValueSubject<[Answer]?, Never> { get }
     var dueTime: CurrentValueSubject<Date?, Never> { get }
     var submits: CurrentValueSubject<[Answer]?, Never> { get }
+    var results: CurrentValueSubject<[Bool]?, Never> { get }
 
     func connectRoom(roomNumber: String)
     func disconnectRoom()

--- a/alsongDalsong/ASRepository/ASRepository/Protocols/RepositoryProtocols.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Protocols/RepositoryProtocols.swift
@@ -57,6 +57,8 @@ public protocol GameStateRepositoryProtocol {
 
 public protocol HummingResultRepositoryProtocol {
     func getResult() -> AnyPublisher<[(answer: Answer, records: [ASEntity.Record], submit: Answer, recordOrder: UInt8)], Never>
+    func getResultsCount() -> AnyPublisher<Int, Never>
+    func submitResult(isFinished: Bool) async throws -> Bool
 }
 
 public protocol DataDownloadRepositoryProtocol {

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/HummingResultRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/HummingResultRepository.swift
@@ -1,15 +1,47 @@
+import ASDecoder
+import ASEncoder
 import ASEntity
+import ASNetworkKit
 import ASRepositoryProtocol
 import Combine
 import Foundation
 
 final class HummingResultRepository: HummingResultRepositoryProtocol {
     private var mainRepository: MainRepositoryProtocol
+    private var networkManager: ASNetworkManagerProtocol
 
     init(
-        mainRepository: MainRepositoryProtocol
+        mainRepository: MainRepositoryProtocol,
+        networkManager: ASNetworkManagerProtocol
     ) {
         self.mainRepository = mainRepository
+        self.networkManager = networkManager
+    }
+
+    func submitResult(isFinished: Bool) async throws -> Bool {
+        do {
+            let queryItems = [
+                URLQueryItem(name: "userId", value: ASFirebaseAuth.myID),
+                URLQueryItem(name: "roomNumber", value: mainRepository.number.value)
+            ]
+            let endPoint = FirebaseEndpoint(path: .submitResult, method: .post)
+                .update(\.queryItems, with: queryItems)
+                .update(\.headers, with: ["Content-Type": "application/json"])
+            let body = try ASEncoder.encode(isFinished)
+            let response = try await networkManager.sendRequest(to: endPoint, type: .json, body: body, option: .none)
+            let responseDict = try ASDecoder.decode([String: String].self, from: response)
+            return !responseDict.isEmpty
+        } catch {
+            throw ASRepositoryErrors(type: .submitResult, reason: error.localizedDescription, file: #file, line: #line)
+        }
+    }
+
+    func getResultsCount() -> AnyPublisher<Int, Never> {
+        mainRepository.results
+            .receive(on: DispatchQueue.main)
+            .compactMap { $0 }
+            .map { $0.count }
+            .eraseToAnyPublisher()
     }
 
     func getResult() ->

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/MainRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/MainRepository.swift
@@ -19,6 +19,7 @@ final class MainRepository: MainRepositoryProtocol {
     var dueTime = CurrentValueSubject<Date?, Never>(nil)
     var submits = CurrentValueSubject<[ASEntity.Answer]?, Never>(nil)
     var records = CurrentValueSubject<[ASEntity.Record]?, Never>(nil)
+    var results = CurrentValueSubject<[Bool]?, Never>(nil)
     var selectedRecords = CurrentValueSubject<[UInt8]?, Never>(nil)
 
     private let databaseManager: ASFirebaseDatabaseProtocol
@@ -54,6 +55,7 @@ final class MainRepository: MainRepositoryProtocol {
                 update(\.dueTime, with: room.dueTime)
                 update(\.submits, with: room.submits)
                 update(\.records, with: room.records)
+                update(\.results, with: room.results)
                 update(\.selectedRecords, with: room.selectedRecords)
             }
             .store(in: &cancellables)
@@ -71,6 +73,7 @@ final class MainRepository: MainRepositoryProtocol {
         update(\.dueTime, with: nil)
         update(\.submits, with: nil)
         update(\.records, with: nil)
+        update(\.results, with: nil)
         update(\.selectedRecords, with: nil)
         databaseManager.removeRoomListener()
     }

--- a/alsongDalsong/ASRepository/ASRepository/RepsotioryAssembly.swift
+++ b/alsongDalsong/ASRepository/ASRepository/RepsotioryAssembly.swift
@@ -86,8 +86,10 @@ public struct RepsotioryAssembly: Assembly {
 
         container.register(HummingResultRepositoryProtocol.self) { r in
             let mainRepository = r.resolve(MainRepositoryProtocol.self)
+            let networkManager = r.resolve(ASNetworkManagerProtocol.self)
             return HummingResultRepository(
-                mainRepository: mainRepository
+                mainRepository: mainRepository,
+                networkManager: networkManager
             )
         }
         

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/Alert/ASAlertController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/Alert/ASAlertController.swift
@@ -184,6 +184,7 @@ enum ASAlertText {
         case startGame
         case submitMusic
         case submitHumming
+        case submitResult
         case nextResult
         case toLobby
         
@@ -193,6 +194,7 @@ enum ASAlertText {
                 case .startGame: "게임을 시작하는 중..."
                 case .submitMusic: "노래를 전송하는 중..."
                 case .submitHumming: "허밍을 전송하는 중..."
+                case .submitResult: "결과 완료를 전송하는 중..."
                 case .nextResult: "다음 결과를 가져오는 중..."
                 case . toLobby: "로비로 이동하는 중..."
             }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/ASErrors.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/ASErrors.swift
@@ -17,6 +17,7 @@ struct ASErrors: LocalizedError {
         case changeRecordOrder, navigateToLobby
         case submitMusic, searchMusicOnSelect, randomMusic
         case searchMusicOnSubmit, submitAnswer
+        case submitResult
     }
 
     var errorDescription: String? {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewController.swift
@@ -9,7 +9,7 @@ class HummingResultViewController: UIViewController {
     private let answerView = MusicPanelView()
     private let resultTableView = UITableView()
     private let nextButton = ASButton()
-
+    private var submissionStatus = SubmissionStatusView()
     private var resultTableViewDiffableDataSource: HummingResultTableViewDiffableDataSource?
     private var viewModel: HummingResultViewModel?
     private var cancellables = Set<AnyCancellable>()
@@ -46,6 +46,7 @@ class HummingResultViewController: UIViewController {
         view.addSubview(resultTableView)
         view.addSubview(nextButton)
         view.addSubview(answerView)
+        view.addSubview(submissionStatus)
     }
 
     private func setResultTableView() {
@@ -68,7 +69,8 @@ class HummingResultViewController: UIViewController {
     private func setAction() {
         nextButton.addAction(UIAction { [weak self] _ in
             guard let self else { return }
-            showNextResultLoading()
+            showSubmitResultLoading()
+//            showNextResultLoading()
         }, for: .touchUpInside)
     }
 
@@ -76,6 +78,7 @@ class HummingResultViewController: UIViewController {
         answerView.translatesAutoresizingMaskIntoConstraints = false
         resultTableView.translatesAutoresizingMaskIntoConstraints = false
         nextButton.translatesAutoresizingMaskIntoConstraints = false
+        submissionStatus.translatesAutoresizingMaskIntoConstraints = false
 
         NSLayoutConstraint.activate([
             answerView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20),
@@ -87,6 +90,9 @@ class HummingResultViewController: UIViewController {
             resultTableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             resultTableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             resultTableView.bottomAnchor.constraint(equalTo: nextButton.topAnchor, constant: -30),
+            // TODO: -
+            submissionStatus.topAnchor.constraint(equalTo: nextButton.topAnchor, constant: -16),
+            submissionStatus.trailingAnchor.constraint(equalTo: nextButton.trailingAnchor, constant: 16),
 
             nextButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
             nextButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
@@ -114,7 +120,7 @@ class HummingResultViewController: UIViewController {
             resultTableViewDiffableDataSource?.applySnapshot((result.answer, [], nil))
         }
     }
-
+    // TODO: -
     private func changeButton(_ phase: ResultPhase) {
         if case .none = phase {
             nextButton.setConfiguration(
@@ -124,24 +130,34 @@ class HummingResultViewController: UIViewController {
             )
             nextButton.isEnabled = true
             nextButton.removeTarget(nil, action: nil, for: .touchUpInside)
-            nextButton.addAction(UIAction { _ in
-                self.showNextResultLoading()
-            }, for: .touchUpInside)
+//            nextButton.addAction(UIAction { _ in
+//                self.showNextResultLoading()
+//            }, for: .touchUpInside)
         } else {
             nextButton.updateButton(.disabled)
+        }
+    }
+
+    private func submitResult() async throws {
+        do {
+            try await viewModel?.submitResult()
+            nextButton.updateButton(.submitted)
+        } catch {
+            throw error
         }
     }
 
     private func bindViewModel() {
         guard let viewModel else { return }
         answerView.bind(to: viewModel.$result)
-
+        submissionStatus.bind(to: viewModel.$submissionStatus)
+        // TODO: -
         viewModel.$resultPhase
             .combineLatest(viewModel.$result, viewModel.$isHost)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] phase, result, isHost in
                 self?.addDataSource(phase, result: result)
-                if result.answer != nil, isHost {
+                if result.answer != nil {
                     self?.changeButton(phase)
                 }
             }
@@ -162,10 +178,40 @@ class HummingResultViewController: UIViewController {
                 }
             }
             .store(in: &cancellables)
+
+        viewModel.$submissionStatus
+            .combineLatest(viewModel.$isHost)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] status, isHost in
+                if status.total != "0",
+                   status.submits == status.total,
+                   isHost {
+                    self?.showNextResultLoading()
+                }
+            }
+            .store(in: &cancellables)
     }
 }
 
 extension HummingResultViewController {
+    // TODO: -
+    private func showSubmitResultLoading() {
+        let alert = LoadingAlertController(
+            progressText: .submitResult,
+            loadAction: { [weak self] in
+                try await self?.submitResult()
+            }
+        ) { [weak self] error in
+            self?.showFailSubmitResult(error)
+        }
+        presentAlert(alert)
+    }
+
+    private func showFailSubmitResult(_ error: Error) {
+        let alert = SingleButtonAlertController(titleText: .error(error))
+        presentAlert(alert)
+    }
+
     private func showNextResultLoading() {
         let alert = LoadingAlertController(
             progressText: .nextResult,

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewModel.swift
@@ -18,6 +18,8 @@ final class HummingResultViewModel: @unchecked Sendable {
     private var dataDownloadRepository: DataDownloadRepositoryProtocol
     private var cancellables = Set<AnyCancellable>()
 
+    @Published private(set) var submissionStatus: (submits: String, total: String) = ("0", "0")
+
     @Published var isHost: Bool = false
     @Published var result: Result = (nil, [], nil)
     @Published var resultPhase: ResultPhase = .none
@@ -181,6 +183,7 @@ extension HummingResultViewModel {
                 guard let self else { return }
                 LogHandler.handleDebug("recordOrder changed \(recordOrder)")
                 updateCurrentResult()
+                bindSubmissionStatus()
             }
             .store(in: &cancellables)
     }
@@ -210,6 +213,28 @@ extension HummingResultViewModel {
                     }
                 }
                 .store(in: &cancellables)
+        }
+    }
+    // TODO: -
+    private func bindSubmissionStatus() {
+        let playerPublisher = playerRepository.getPlayersCount()
+        let resultsPublisher = hummingResultRepository.getResultsCount()
+
+        playerPublisher.combineLatest(resultsPublisher)
+            .sink { [weak self] playersCount, resultsCount in
+                let submitStatus = (submits: String(resultsCount), total: String(playersCount))
+                self?.submissionStatus = submitStatus
+            }
+            .store(in: &cancellables)
+    }
+
+    func submitResult() async throws {
+        do {
+            let _ = try await hummingResultRepository.submitResult(isFinished: true)
+        } catch {
+            let error = ASErrors(type: .submitResult, reason: error.localizedDescription, file: #file, line: #line)
+            LogHandler.handleError(error)
+            throw error
         }
     }
 


### PR DESCRIPTION
## 필수 리뷰어

- none

## 관련 이슈

- #11 

## 완료 및 수정 내역

 - [x] 결과 화면 내 준비 완료 여부 송신
 - [x] 결과 화면 내 준비 완료 여부 수신
 - [ ] firebase의 index.js 등 추가
 - [x] 결과 화면에 준비 완료된 사용자의 수 표시
 - [x] 모든 준비 완료에 따른 다음 화면 전환

## 리뷰 노트

### 결과 화면에서 호스트의 다음 액션을 기다리는 동안 어떤 일이 진행중인지 알 수 없는 상황
이전 단계처럼 다른 사용자의 진행도(해당 결과 화면 완료 여부)를 버튼 위에 표시해줌으로 다른 사용자들이 어느 상황인지 알 수 있게 합니다.

### 완료 여부 표시를 위한 과정
우선 이전 단계에서 해당 부분이 어떻게 동작하는지 파악, 결과 화면에서도 동일하게 각 사용자가 버튼을 눌러 준비완료를 하도록 생각했습니다.
이때 호스트의 버튼은 비활성화 되어있다가 다른 모든 사용자가 준비 완료시 호스트의 버튼이 활성화 되고, 호스트가 버튼을 누를 시 기존과 동일하게 모든 사용자의 화면이 넘어가도록 1차 설계했습니다.

이 과정에서 firebase의 Index.js 등의 파일 수정 및 추가가 필요했지만, 이로 인해 해당 PR이 머지 되기 전에 다른 팀원들의 테스트 과정에서 문제가 발생할 수 있을 듯 하여 대기하였고, 금요일(03.14) 회의를 통해 해당 Issue를 반영하지 않기로 결정했습니다.

결정 사유는, 결과 화면의 순서의 차이가 크지 않기 때문에 호스트가 아닌 다른 사용자가 대기하는 시간이 적어 준비 완료 여부를 동기화 하는 조건이 불필요하다 였습니다. 

대신 해당 문제를 해결하기 위해 인예님이 호스트가 아닌 다른 사용자의 버튼 문구를 "다른 사용자를 기다리는 중..." 과 같이 수정하기로 했습니다.
