### PR TITLE
[refactor] 결과화면 버튼 UX 개선

### DIFF
--- a/alsongDalsong/alsongDalsong/alsongDalsong/Localizable.xcstrings
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Localizable.xcstrings
@@ -235,6 +235,16 @@
         }
       }
     },
+    "다음 결과 대기 중" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Waiting for the next result"
+          }
+        }
+      }
+    },
     "다음 결과를 가져오는 중..." : {
       "extractionState" : "manual",
       "localizations" : {
@@ -450,6 +460,16 @@
         }
       }
     },
+    "방장이 로비로 이동 중" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Host moving to the lobby"
+          }
+        }
+      }
+    },
     "부드러운" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -482,6 +502,17 @@
         }
       }
     },
+    "삶" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Life"
+          }
+        }
+      }
+    },
     "사냥꾼" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -500,17 +531,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Master"
-          }
-        }
-      }
-    },
-    "삶" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Life"
           }
         }
       }
@@ -829,7 +849,14 @@
       }
     },
     "튜토리얼 완료" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Complete"
+          }
+        }
+      }
     },
     "틀틀보" : {
       "extractionState" : "manual",

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Localizable.xcstrings
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Localizable.xcstrings
@@ -204,13 +204,12 @@
         }
       }
     },
-    "녹음중.." : {
-      "extractionState" : "manual",
+    "녹음중" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Recording..."
+            "value" : "Recording"
           }
         }
       }
@@ -456,16 +455,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Are you sure you want to leave the room?"
-          }
-        }
-      }
-    },
-    "방장이 로비로 이동 중" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Host moving to the lobby"
           }
         }
       }
@@ -771,6 +760,9 @@
           }
         }
       }
+    },
+    "종료 대기 중" : {
+
     },
     "찰나의 순간" : {
       "extractionState" : "manual",

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
@@ -101,14 +101,13 @@ final class ASButton: UIButton {
         case disabled
         case needMorePlayers
         case idle(String, UIColor?)
-        case startRecord
-        case recording
-        case reRecord
+        case startRecord, recording, reRecord
         case complete
-        case submit
-        case submitted
+        case submit, submitted
         case startGame
-        case hostSelecting
+        case startWaiting, endWaiting
+        case next
+        case nextResultWaiting
 
         var text: String? {
             switch self {
@@ -122,13 +121,16 @@ final class ASButton: UIButton {
                 case .submit: String(localized: "제출하기")
                 case .submitted: String(localized: "제출 완료")
                 case .startGame: String(localized: "시작하기!")
-                case .hostSelecting: String(localized: "시작 대기 중")
-                }
+                case .startWaiting: String(localized: "시작 대기 중")
+                case .endWaiting: String(localized: "종료 대기 중")
+                case .next: String(localized: "다음으로")
+                case .nextResultWaiting: String(localized: "다음 결과 대기 중")
+            }
         }
 
         var systemImage: String? {
             switch self {
-                case .startGame: "play.fill"
+                case .startGame, .next: "play.fill"
                 case .reRecord: "arrow.clockwise"
                 default: nil
             }
@@ -143,7 +145,8 @@ final class ASButton: UIButton {
                 case .reRecord: .asOrange
                 case .complete: .asYellow
                 case .submit: .asGreen
-                case .startGame: .asMint
+                case .startGame, .next: .asMint
+                case .endWaiting, .nextResultWaiting: .systemGray2
                 default: nil
             }
         }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
@@ -117,7 +117,7 @@ final class ASButton: UIButton {
                 case .needMorePlayers: String(localized: "게임 인원 부족")
                 case let .idle(string, _): string
                 case .startRecord: String(localized: "녹음하기")
-                case .recording: String(localized: "녹음중..")
+                case .recording: String(localized: "녹음중")
                 case .reRecord: String(localized: "재녹음")
                 case .complete: String(localized: "완료")
                 case .submit: String(localized: "제출하기")

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
@@ -52,7 +52,7 @@ final class LobbyViewController: UIViewController {
                     }
                 }
                 else {
-                    self?.startButton.updateButton(.hostSelecting)
+                    self?.startButton.updateButton(.startWaiting)
                     self?.startButton.updateButton(.disabled)
                 }
             }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewController.swift
@@ -57,11 +57,9 @@ class HummingResultViewController: UIViewController {
     }
 
     private func setButton() {
-        nextButton.setConfiguration(
-            systemImageName: "play.fill",
-            text: String(localized: "다음으로"),
-            backgroundColor: .asMint
-        )
+        viewModel?.isHost == true
+        ? nextButton.updateButton(.next)
+        : nextButton.updateButton(.nextResultWaiting)
         nextButton.updateButton(.disabled)
     }
 
@@ -117,21 +115,21 @@ class HummingResultViewController: UIViewController {
 
     private func changeButton(_ phase: ResultPhase) {
         if case .none = phase {
-            nextButton.setConfiguration(
-                systemImageName: "play.fill",
-                text: String(localized: "다음으로"),
-                backgroundColor: .asMint
-            )
-            nextButton.isEnabled = true
-            nextButton.removeTarget(nil, action: nil, for: .touchUpInside)
-            nextButton.addAction(UIAction { _ in
-                self.showNextResultLoading()
-            }, for: .touchUpInside)
+            if viewModel?.totalResult.isEmpty == true {
+                nextButton.updateButton(.complete)
+            } else {
+                nextButton.updateButton(.next)
+                nextButton.isEnabled = true
+                nextButton.removeTarget(nil, action: nil, for: .touchUpInside)
+                nextButton.addAction(UIAction { _ in
+                    self.showNextResultLoading()
+                }, for: .touchUpInside)
+            }
         } else {
             nextButton.updateButton(.disabled)
         }
     }
-
+    
     private func bindViewModel() {
         guard let viewModel else { return }
         answerView.bind(to: viewModel.$result)
@@ -151,7 +149,10 @@ class HummingResultViewController: UIViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] canEndGame in
                 if canEndGame {
-                    self?.nextButton.updateButton(.complete)
+                    guard viewModel.isHost else {
+                        self?.nextButton.updateButton(.endWaiting)
+                        return
+                    }
                     self?.nextButton.isEnabled = true
                     self?.nextButton.removeTarget(nil, action: nil, for: .touchUpInside)
                     self?.nextButton.addAction(UIAction { _ in


### PR DESCRIPTION
## 필수 리뷰어
@around-forest 

## 관련 이슈

- #1

## 완료 및 수정 내역

 - [x] host와 guest 버튼 구분
 - [x] `완료` 텍스트가 뜨는 시점 변경
    - 기존: 마지막 결과까지 플레이 후 버튼 텍스트가 `완료`로 변경
    - 변경 후: 마지막 결과 페이지에 진입하면 버튼 텍스트가 `완료`로 변경

## 테스트 방법 (선택)

## 리뷰 노트

## 스크린샷 (선택)

개선 후:

|  결과확인 1/2 진입 | 다 듣고 난 뒤  |
| -- | -- |
| <img width="679" alt="1" src="https://github.com/user-attachments/assets/ae90b834-492e-46b1-8ae4-087e45ac857b" /> | <img width="685" alt="2" src="https://github.com/user-attachments/assets/d377a402-7a7d-4941-b950-9c79c1054424" /> |

|  결과확인 2/2 진입 | 다 듣고 난 뒤  |
| -- | -- |
| <img width="685" alt="3" src="https://github.com/user-attachments/assets/4dab6ab4-a4ac-4a41-8f6c-9ad9c45c8c40" /> | <img width="675" alt="4" src="https://github.com/user-attachments/assets/1a8befb5-0768-4e42-9067-8ab270365960" /> |

