### PR TITLE
[refactor] let으로 변경해 불변성을 유지

### DIFF
--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GameNavigationController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GameNavigationController.swift
@@ -10,6 +10,7 @@ final class GameNavigationController: @unchecked Sendable {
     private let gameStateRepository: GameStateRepositoryProtocol
     private let roomActionRepository: RoomActionRepositoryProtocol
     private var subscriptions: Set<AnyCancellable> = []
+    private let roomNumber: String
 
     private var gameInfo: GameState? {
         didSet {
@@ -17,8 +18,6 @@ final class GameNavigationController: @unchecked Sendable {
             updateViewControllers(state: gameInfo)
         }
     }
-
-    private let roomNumber: String
 
     init(navigationController: UINavigationController,
          gameStateRepository: GameStateRepositoryProtocol,

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
@@ -1,14 +1,14 @@
 import UIKit
 
 final class HummingViewController: UIViewController {
-    private var progressBar = ProgressBar()
+    private let progressBar = ProgressBar()
     private let scrollView = UIScrollView()
-    private var musicPanel = MusicPanel()
-    private var hummingPanel = RecordingPanel(.asYellow)
-    private var recordButton = ASButton()
-    private var submitButton = ASButton()
-    private var submissionStatus = SubmissionStatusView()
-    private var buttonStack = UIStackView()
+    private let musicPanel = MusicPanel()
+    private let hummingPanel = RecordingPanel(.asYellow)
+    private let recordButton = ASButton()
+    private let submitButton = ASButton()
+    private let submissionStatus = SubmissionStatusView()
+    private let buttonStack = UIStackView()
     private let viewModel: HummingViewModel
 
     init(viewModel: HummingViewModel) {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewController.swift
@@ -5,9 +5,9 @@ import Combine
 import UIKit
 
 final class LoadingViewController: UIViewController {
-    private var logoImageView = UIImageView(image: UIImage(named: "logo"))
-    private var activityIndicatorView = UIActivityIndicatorView(style: .large)
-    private var loadingStatusLabel = UILabel()
+    private let logoImageView = UIImageView(image: UIImage(named: "logo"))
+    private let activityIndicatorView = UIActivityIndicatorView(style: .large)
+    private let loadingStatusLabel = UILabel()
     private var viewModel: LoadingViewModel?
     private var inviteCode = ""
     private var cancellables = Set<AnyCancellable>()

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewModel.swift
@@ -2,8 +2,8 @@ import ASRepositoryProtocol
 import Foundation
 
 final class LoadingViewModel: @unchecked Sendable {
-    private var avatarRepository: AvatarRepositoryProtocol
-    private var dataDownloadRepository: DataDownloadRepositoryProtocol
+    private let avatarRepository: AvatarRepositoryProtocol
+    private let dataDownloadRepository: DataDownloadRepositoryProtocol
     private(set) var avatars: [URL] = []
     private(set) var selectedAvatar: URL?
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyView.swift
@@ -4,6 +4,7 @@ struct LobbyView: View {
     @ObservedObject var viewModel: LobbyViewModel
     @State var isPresented = false
     @Environment(\.dismiss) var dismiss
+    
     var body: some View {
         VStack {
             ScrollView(.horizontal) {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewModel.swift
@@ -4,10 +4,10 @@ import Combine
 import Foundation
 
 final class LobbyViewModel: ObservableObject, @unchecked Sendable {
-    private var playersRepository: PlayersRepositoryProtocol
-    private var roomInfoRepository: RoomInfoRepositoryProtocol
-    private var roomActionRepository: RoomActionRepositoryProtocol
-    private var dataDownloadRepository: DataDownloadRepositoryProtocol
+    private let playersRepository: PlayersRepositoryProtocol
+    private let roomInfoRepository: RoomInfoRepositoryProtocol
+    private let roomActionRepository: RoomActionRepositoryProtocol
+    private let dataDownloadRepository: DataDownloadRepositoryProtocol
 
     let playerMaxCount = 4
     private(set) var roomNumber: String = ""

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/MusicPanel/ASMusicPlayerView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/MusicPanel/ASMusicPlayerView.swift
@@ -2,10 +2,10 @@ import Combine
 import UIKit
 
 final class ASMusicPlayerView: UIView {
-    private var backgroundImageView = UIImageView()
+    private let backgroundImageView = UIImageView()
     private var blurView = UIVisualEffectView()
-    private var playButton = UIButton()
-    private var panelType: MusicPanelType
+    private let playButton = UIButton()
+    private let panelType: MusicPanelType
     var onPlayButtonTapped: ((MusicPanelType) -> Void)?
     private var cancellables = Set<AnyCancellable>()
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/MusicPanel/MusicPanel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/MusicPanel/MusicPanel.swift
@@ -15,6 +15,7 @@ final class MusicPanel: UIView {
     private let titleLabel = UILabel()
     private let artistLabel = UILabel()
     private let labelStack = UIStackView()
+    
     private var cancellables = Set<AnyCancellable>()
     private var viewModel: MusicPanelViewModel? = nil
     private var panelType: MusicPanelType = .large

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewController.swift
@@ -5,14 +5,14 @@ import Combine
 import UIKit
 
 final class OnboardingViewController: UIViewController {
-    private var logoImageView = UIImageView(image: UIImage(named: Constants.logoImageName))
-    private var createRoomButton = ASButton()
-    private var joinRoomButton = ASButton()
-    private var avatarView = ASAvatarCircleView()
-    private var nickNamePanel = NicknamePanel()
-    private var avatarRefreshButton = ASRefreshButton(size: 28)
+    private let logoImageView = UIImageView(image: UIImage(named: Constants.logoImageName))
+    private let createRoomButton = ASButton()
+    private let joinRoomButton = ASButton()
+    private let avatarView = ASAvatarCircleView()
+    private let nickNamePanel = NicknamePanel()
+    private let avatarRefreshButton = ASRefreshButton(size: 28)
+    private let inviteCode: String
     private var viewModel: OnboardingViewModel?
-    private var inviteCode: String
     private var gameNavigationController: GameNavigationController?
     private var cancellables = Set<AnyCancellable>()
     var shouldMoveKeyboard: Bool = true

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewController.swift
@@ -15,7 +15,7 @@ final class OnboardingViewController: UIViewController {
     private var viewModel: OnboardingViewModel?
     private var gameNavigationController: GameNavigationController?
     private var cancellables = Set<AnyCancellable>()
-    var shouldMoveKeyboard: Bool = true
+    private var shouldMoveKeyboard: Bool = true
 
     init(viewModel: OnboardingViewModel, inviteCode: String) {
         self.viewModel = viewModel

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewModel.swift
@@ -3,8 +3,8 @@ import ASRepositoryProtocol
 import Foundation
 
 final class OnboardingViewModel: @unchecked Sendable {
-    private var roomActionRepository: RoomActionRepositoryProtocol
-    private var dataDownloadRepository: DataDownloadRepositoryProtocol
+    private let roomActionRepository: RoomActionRepositoryProtocol
+    private let dataDownloadRepository: DataDownloadRepositoryProtocol
     private var avatars: [URL] = []
     private var selectedAvatar: URL?
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/RecordingPanel/RecordingPanel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/RecordingPanel/RecordingPanel.swift
@@ -2,11 +2,11 @@ import Combine
 import UIKit
 
 final class RecordingPanel: UIView {
-    private var playButton = UIButton()
-    private var waveFormView = WaveForm()
-    private var customBackgroundColor: UIColor
-    private var cancellables = Set<AnyCancellable>()
+    private let playButton = UIButton()
+    private let waveFormView = WaveForm()
+    private let customBackgroundColor: UIColor
     private let viewModel = RecordingPanelViewModel()
+    private var cancellables = Set<AnyCancellable>()
     var onRecordingFinished: ((Data) -> Void)?
 
     init(_ color: UIColor = .asMint) {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/RecordingPanel/RecordingPanelViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/RecordingPanel/RecordingPanelViewModel.swift
@@ -2,7 +2,7 @@ import Combine
 import Foundation
 
 final class RecordingPanelViewModel: @unchecked Sendable {
-    let sampleCount: Int = 48
+    private let sampleCount: Int = 48
     @Published var recordedData: Data?
     @Published private(set) var recorderAmplitude: Float = 0.0
     @Published private(set) var buttonState: AudioButtonState = .idle

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingView.swift
@@ -1,14 +1,14 @@
 import UIKit
 
 final class RehummingViewController: UIViewController {
-    private var progressBar = ProgressBar()
+    private let progressBar = ProgressBar()
     private let scrollView = UIScrollView()
-    private var musicPanel = MusicPanel()
-    private var hummingPanel = RecordingPanel(.asMint)
-    private var recordButton = ASButton()
-    private var submitButton = ASButton()
-    private var submissionStatus = SubmissionStatusView()
-    private var buttonStack = UIStackView()
+    private let musicPanel = MusicPanel()
+    private let hummingPanel = RecordingPanel(.asMint)
+    private let recordButton = ASButton()
+    private let submitButton = ASButton()
+    private let submissionStatus = SubmissionStatusView()
+    private let buttonStack = UIStackView()
     private let viewModel: RehummingViewModel
 
     init(viewModel: RehummingViewModel) {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewModel+Entity.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewModel+Entity.swift
@@ -6,10 +6,10 @@ protocol PlayerInfo {
 }
 
 struct MappedAnswer: Hashable, PlayerInfo {
-    var artworkData: Data
-    var previewData: Data
-    var title: String
-    var artist: String
+    let artworkData: Data
+    let previewData: Data
+    let title: String
+    let artist: String
     var playerName: String
     var playerAvatarData: Data
 
@@ -24,9 +24,9 @@ struct MappedAnswer: Hashable, PlayerInfo {
 }
 
 struct MappedRecord: Hashable, PlayerInfo {
-    var recordData: Data?
+    let recordData: Data?
     var midiURL: URL?
-    var recordAmplitudes: [CGFloat]
+    let recordAmplitudes: [CGFloat]
     var playerName: String
     var playerAvatarData: Data
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewModel.swift
@@ -10,12 +10,12 @@ typealias Result = (
 )
 
 final class HummingResultViewModel: @unchecked Sendable {
-    private var hummingResultRepository: HummingResultRepositoryProtocol
-    private var gameStatusRepository: GameStatusRepositoryProtocol
-    private var playerRepository: PlayersRepositoryProtocol
-    private var roomActionRepository: RoomActionRepositoryProtocol
-    private var roomInfoRepository: RoomInfoRepositoryProtocol
-    private var dataDownloadRepository: DataDownloadRepositoryProtocol
+    private let hummingResultRepository: HummingResultRepositoryProtocol
+    private let gameStatusRepository: GameStatusRepositoryProtocol
+    private let playerRepository: PlayersRepositoryProtocol
+    private let roomActionRepository: RoomActionRepositoryProtocol
+    private let roomInfoRepository: RoomInfoRepositoryProtocol
+    private let dataDownloadRepository: DataDownloadRepositoryProtocol
     private var cancellables = Set<AnyCancellable>()
 
     @Published var isHost: Bool = false

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/ASSearchBar.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/ASSearchBar.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct ASSearchBar: View {
     @Binding var text: String
-    var placeHolder: String
+    let placeHolder: String
     
     var body: some View {
         HStack {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewController.swift
@@ -1,11 +1,11 @@
 import SwiftUI
 
 final class SelectMusicViewController: UIViewController {
-    private var progressBar = ProgressBar()
-    private var selectMusicView = UIViewController()
+    private let progressBar = ProgressBar()
     private let submitButton = ASButton()
-    private var submissionStatus = SubmissionStatusView()
+    private let submissionStatus = SubmissionStatusView()
     private let viewModel: SelectMusicViewModel
+    private var selectMusicView = UIViewController()
     
     init(selectMusicViewModel: SelectMusicViewModel) {
         self.viewModel = selectMusicViewModel

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
@@ -25,7 +25,7 @@ final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
     private let answersRepository: AnswersRepositoryProtocol
     private let gameStatusRepository: GameStatusRepositoryProtocol
     private let dataDownloadRepository: DataDownloadRepositoryProtocol
-    
+
     private let musicAPI = ASMusicAPI()
     private var cancellables = Set<AnyCancellable>()
     

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewController.swift
@@ -2,16 +2,16 @@ import Combine
 import SwiftUI
 
 final class SubmitAnswerViewController: UIViewController {
-    private var progressBar = ProgressBar()
+    private let progressBar = ProgressBar()
     private let scrollView = UIScrollView()
-    private var musicPanel = MusicPanel()
-    private var selectedMusicPanel = MusicPanel(.compact)
-    private var selectAnswerButton = ASButton()
-    private var submitButton = ASButton()
-    private var submissionStatus = SubmissionStatusView()
-    private var selectedAnswerView: UIHostingController<SelectAnswerView>?
-    private var buttonStack = UIStackView()
+    private let musicPanel = MusicPanel()
+    private let selectedMusicPanel = MusicPanel(.compact)
+    private let selectAnswerButton = ASButton()
+    private let submitButton = ASButton()
+    private let submissionStatus = SubmissionStatusView()
+    private let buttonStack = UIStackView()
     private let viewModel: SubmitAnswerViewModel
+    private var selectedAnswerView: UIHostingController<SelectAnswerView>?
 
     init(viewModel: SubmitAnswerViewModel) {
         self.viewModel = viewModel

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Tutorial/SubmitAnswer/SubmitAnswerTutorialViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Tutorial/SubmitAnswer/SubmitAnswerTutorialViewController.swift
@@ -2,13 +2,13 @@ import SwiftUI
 import ASEntity
 
 final class SubmitAnswerTutorialViewController: UIViewController {
-    private var progressBar = ProgressBar()
+    private let progressBar = ProgressBar()
     private let scrollView = UIScrollView()
-    private var musicPanel = MusicPanel()
-    private var selectedMusicPanel = MusicPanel(.compact)
-    private var selectAnswerButton = ASButton()
+    private let musicPanel = MusicPanel()
+    private let selectedMusicPanel = MusicPanel(.compact)
+    private let selectAnswerButton = ASButton()
     private let submitButton = ASButton()
-    private var buttonStack = UIStackView()
+    private let buttonStack = UIStackView()
     
     private let viewModel: SubmitAnswerTutorialViewModel
     


### PR DESCRIPTION
## 필수 리뷰어

## 관련 이슈

- #26 

## 완료 및 수정 내역

 - [x] 접근 제어자 개선
 - [x] var -> let으로 변경

## 테스트 방법 (선택)

## 리뷰 노트

현재 일부 프로퍼티가 var로 선언되어 있지만 실제로 참조가 변경되지 않았기에 let으로 변경하여 불변성을 유지하고, 코드의 안정성을 높였습니다.
추가로 외부에서 사용하지 않는 프로퍼티 접근제어자를 함께 변경했습니다.

## 스크린샷 (선택)
