### PR TITLE
[feat] 방장 강퇴기능 추가

### DIFF
--- a/alsongDalsong/ASEntity/ASEntity/Room.swift
+++ b/alsongDalsong/ASEntity/ASEntity/Room.swift
@@ -13,4 +13,5 @@ public struct Room: Codable {
     public var dueTime: Date?
     public var selectedRecords: [UInt8]?
     public var submits: [Answer]?
+    public var bannedPlayers: [String]?
 }

--- a/alsongDalsong/ASNetworkKit/ASNetworkKit/ASNetworkManager.swift
+++ b/alsongDalsong/ASNetworkKit/ASNetworkKit/ASNetworkManager.swift
@@ -96,6 +96,7 @@ private extension ASNetworkManager {
         case serviceUnavailable = 503
         case gatewayTimeout = 504
         case startedRoom = 452
+        case bannedPlayer = 453
         case unknown
 
         var description: String {
@@ -144,6 +145,8 @@ private extension ASNetworkManager {
                     return "게이트웨이 시간 초과: 게이트웨이가 요청에 대한 응답을 받지 못했습니다."
                 case .startedRoom:
                     return "이미 게임이 시작된 방입니다."
+                case .bannedPlayer:
+                    return "해당 방에서 강퇴되어 참여할 수 없습니다."
                 case .unknown:
                     return "알 수 없는 오류: 예상하지 못한 오류가 발생했습니다."
             }

--- a/alsongDalsong/ASNetworkKit/ASNetworkKit/FirebaseEndpoint.swift
+++ b/alsongDalsong/ASNetworkKit/ASNetworkKit/FirebaseEndpoint.swift
@@ -29,6 +29,7 @@ public struct FirebaseEndpoint: Endpoint, Equatable {
         case submitMusic
         case submitAnswer
         case resetGame
+        case kickPlayer
       
         public var description: String {
             switch self {
@@ -52,6 +53,8 @@ public struct FirebaseEndpoint: Endpoint, Equatable {
                     "/changeRecordOrder"
                 case .resetGame:
                     "/resetGame"
+                case .kickPlayer:
+                    "/kickPlayer"
             }
         }
     }

--- a/alsongDalsong/ASRepository/ASRepository/ASRepositoryErrors.swift
+++ b/alsongDalsong/ASRepository/ASRepository/ASRepositoryErrors.swift
@@ -11,7 +11,7 @@ struct ASRepositoryErrors: LocalizedError {
         case getAvatarUrls
         case postRecording, postResetGame
         case uploadRecording
-        case createRoom, joinRoom, leaveRoom, startGame, changeMode, changeRecordOrder, resetGame, sendRequest
+        case createRoom, joinRoom, leaveRoom, startGame, changeMode, changeRecordOrder, resetGame, sendRequest, kickUser
         case submitAnswer
     }
 

--- a/alsongDalsong/ASRepository/ASRepository/Mock/GameStateMockRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Mock/GameStateMockRepository.swift
@@ -18,4 +18,9 @@ public final class GameStateMockRepository: GameStateRepositoryProtocol {
         gameStatePublisher
             .eraseToAnyPublisher()
     }
+    
+    public func receiveKickOut() -> AnyPublisher<Bool, Never> {
+        CurrentValueSubject<Bool, Never>(false)
+            .eraseToAnyPublisher()
+    }
 }

--- a/alsongDalsong/ASRepository/ASRepository/Mock/RoomActionMockRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Mock/RoomActionMockRepository.swift
@@ -32,4 +32,8 @@ public final class RoomActionMockRepository: RoomActionRepositoryProtocol {
     public func resetGame() async throws -> Bool {
         true
     }
+    
+    public func kickPlayer(roomNumber: String, userID: String) async throws -> Bool {
+        true
+    }
 }

--- a/alsongDalsong/ASRepository/ASRepository/Protocols/MainRepositoryProtocol.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Protocols/MainRepositoryProtocol.swift
@@ -15,6 +15,8 @@ public protocol MainRepositoryProtocol {
     var answers: CurrentValueSubject<[Answer]?, Never> { get }
     var dueTime: CurrentValueSubject<Date?, Never> { get }
     var submits: CurrentValueSubject<[Answer]?, Never> { get }
+    
+    var isKickedOut: PassthroughSubject<Bool, Never> { get }
 
     func connectRoom(roomNumber: String)
     func disconnectRoom()

--- a/alsongDalsong/ASRepository/ASRepository/Protocols/MainRepositoryProtocol.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Protocols/MainRepositoryProtocol.swift
@@ -15,7 +15,6 @@ public protocol MainRepositoryProtocol {
     var answers: CurrentValueSubject<[Answer]?, Never> { get }
     var dueTime: CurrentValueSubject<Date?, Never> { get }
     var submits: CurrentValueSubject<[Answer]?, Never> { get }
-    
     var isKickedOut: PassthroughSubject<Bool, Never> { get }
 
     func connectRoom(roomNumber: String)

--- a/alsongDalsong/ASRepository/ASRepository/Protocols/RepositoryProtocols.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Protocols/RepositoryProtocols.swift
@@ -50,6 +50,7 @@ public protocol RoomActionRepositoryProtocol: Sendable {
     func changeMode(roomNumber: String, mode: Mode) async throws -> Bool
     func changeRecordOrder(roomNumber: String) async throws -> Bool
     func resetGame() async throws -> Bool
+    @discardableResult func kickPlayer(roomNumber: String, userID: String) async throws -> Bool
 }
 
 public protocol GameStateRepositoryProtocol {

--- a/alsongDalsong/ASRepository/ASRepository/Protocols/RepositoryProtocols.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Protocols/RepositoryProtocols.swift
@@ -55,6 +55,7 @@ public protocol RoomActionRepositoryProtocol: Sendable {
 
 public protocol GameStateRepositoryProtocol {
     func getGameState() -> AnyPublisher<GameState?, Never>
+    func receiveKickOut() -> AnyPublisher<Bool, Never>
 }
 
 public protocol HummingResultRepositoryProtocol {

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/GameStateRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/GameStateRepository.swift
@@ -19,4 +19,10 @@ final class GameStateRepository: GameStateRepositoryProtocol {
             }
             .eraseToAnyPublisher()
     }
+    
+    func receiveKickOut() -> AnyPublisher<Bool, Never> {
+        mainRepository.isKickedOut
+            .receive(on: DispatchQueue.main)
+            .eraseToAnyPublisher()
+    }
 }

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/GameStateRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/GameStateRepository.swift
@@ -22,7 +22,6 @@ final class GameStateRepository: GameStateRepositoryProtocol {
     
     func receiveKickOut() -> AnyPublisher<Bool, Never> {
         mainRepository.isKickedOut
-            .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()
     }
 }

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/MainRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/MainRepository.swift
@@ -2,9 +2,9 @@ import ASDecoder
 import ASEntity
 import ASLogKit
 import ASNetworkKit
+import ASRepositoryProtocol
 import Combine
 import Foundation
-import ASRepositoryProtocol
 
 final class MainRepository: MainRepositoryProtocol {
     var myId: String? { ASFirebaseAuth.myID }
@@ -20,6 +20,8 @@ final class MainRepository: MainRepositoryProtocol {
     var submits = CurrentValueSubject<[ASEntity.Answer]?, Never>(nil)
     var records = CurrentValueSubject<[ASEntity.Record]?, Never>(nil)
     var selectedRecords = CurrentValueSubject<[UInt8]?, Never>(nil)
+
+    var isKickedOut = PassthroughSubject<Bool, Never>()
 
     private let databaseManager: ASFirebaseDatabaseProtocol
     private let networkManager: ASNetworkManagerProtocol
@@ -43,6 +45,14 @@ final class MainRepository: MainRepositoryProtocol {
                 }
             } receiveValue: { [weak self] room in
                 guard let self else { return }
+
+                if let bannedPlayerIDList = room.bannedPlayers, let myID = ASFirebaseAuth.myID {
+                    if bannedPlayerIDList.contains(myID) {
+                        isKickedOut.send(true)
+                        return
+                    }
+                }
+
                 update(\.number, with: room.number)
                 update(\.host, with: room.host)
                 update(\.players, with: room.players)
@@ -61,6 +71,7 @@ final class MainRepository: MainRepositoryProtocol {
 
     func disconnectRoom() {
         databaseManager.removeRoomListener()
+        cancellables.removeAll()
         update(\.number, with: nil)
         update(\.host, with: nil)
         update(\.players, with: nil)
@@ -105,7 +116,7 @@ final class MainRepository: MainRepositoryProtocol {
             throw ASRepositoryErrors(type: .postRecording, reason: error.localizedDescription, file: #file, line: #line)
         }
     }
-    
+
     func postResetGame() async throws -> Bool {
         do {
             let queryItems = [URLQueryItem(name: "userId", value: ASFirebaseAuth.myID),

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/MainRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/MainRepository.swift
@@ -20,7 +20,6 @@ final class MainRepository: MainRepositoryProtocol {
     var submits = CurrentValueSubject<[ASEntity.Answer]?, Never>(nil)
     var records = CurrentValueSubject<[ASEntity.Record]?, Never>(nil)
     var selectedRecords = CurrentValueSubject<[UInt8]?, Never>(nil)
-
     var isKickedOut = PassthroughSubject<Bool, Never>()
 
     private let databaseManager: ASFirebaseDatabaseProtocol

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/RoomActionRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/RoomActionRepository.swift
@@ -82,7 +82,7 @@ final class RoomActionRepository: RoomActionRepositoryProtocol {
                 endpointPath: .changeMode,
                 requestBody: ["roomNumber": roomNumber, "userId": ASFirebaseAuth.myID, "mode": mode.rawValue]
             )
-            guard let isSuccess = response["success"] as? Bool else {
+            guard let isSuccess = response["success"] else {
                 throw ASNetworkErrors(type: .responseError, reason: "", file: #file, line: #line)
             }
             return isSuccess
@@ -97,7 +97,7 @@ final class RoomActionRepository: RoomActionRepositoryProtocol {
                 endpointPath: .changeRecordOrder,
                 requestBody: ["roomNumber": roomNumber, "userId": ASFirebaseAuth.myID]
             )
-            guard let isSuccess = response["success"] as? Bool else {
+            guard let isSuccess = response["success"] else {
                 throw ASNetworkErrors(type: .responseError, reason: "", file: #file, line: #line)
             }
             return isSuccess
@@ -111,6 +111,21 @@ final class RoomActionRepository: RoomActionRepositoryProtocol {
             return try await mainRepository.postResetGame()
         } catch {
             throw ASRepositoryErrors(type: .resetGame, reason: error.localizedDescription, file: #file, line: #line)
+        }
+    }
+    
+    func kickPlayer(roomNumber: String, userID: String) async throws -> Bool {
+        do {
+            let response: [String: Bool] = try await self.sendRequest(
+                endpointPath: .kickPlayer,
+                requestBody: ["roomNumber": roomNumber, "hostId": ASFirebaseAuth.myID, "playerId": userID]
+            )
+            guard let isSuccess = response["success"] else {
+                throw ASNetworkErrors(type: .responseError, reason: "", file: #file, line: #line)
+            }
+            return isSuccess
+        } catch {
+            throw ASRepositoryErrors(type: .kickUser, reason: error.localizedDescription, file: #file, line: #line)
         }
     }
     

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Localizable.xcstrings
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Localizable.xcstrings
@@ -262,29 +262,29 @@
         }
       }
     },
+    "님을 강퇴하시겠습니까?\\n강퇴 시 기존 방에는 영구적으로 재입장이 불가능합니다!" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Are you sure you want to kick %@ out?\\nOnce kicked, they will not be able to rejoin the room permanently!"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@님을 강퇴하시겠습니까?\\n강퇴 시 기존 방에는 영구적으로 재입장이 불가능합니다!"
+          }
+        }
+      }
+    },
     "다음 결과 대기 중" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Waiting for the next result"
-          }
-        }
-      }
-    },
-    "님을 강퇴하시겠습니까?" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Would you like to kick %@ out?"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@님을 강퇴하시겠습니까?"
           }
         }
       }
@@ -547,28 +547,6 @@
         }
       }
     },
-    "사부님" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Master"
-          }
-        }
-      }
-    },
-    "삶" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Life"
-          }
-        }
-      }
-    },
     "사냥꾼" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -576,6 +554,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hunter"
+          }
+        }
+      }
+    },
+    "사부님" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Master"
           }
         }
       }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Localizable.xcstrings
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Localizable.xcstrings
@@ -45,6 +45,23 @@
         }
       }
     },
+    "강퇴 하기" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kick Out"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "강퇴 하기"
+          }
+        }
+      }
+    },
     "개발자" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -240,6 +257,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Waiting for the next result"
+          }
+        }
+      }
+    },
+    "님을 강퇴하시겠습니까?" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Would you like to kick %@ out?"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@님을 강퇴하시겠습니까?"
           }
         }
       }
@@ -509,6 +543,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hunter"
+          }
+        }
+      }
+    },
+    "삶" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Life"
           }
         }
       }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Localizable.xcstrings
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Localizable.xcstrings
@@ -45,6 +45,17 @@
         }
       }
     },
+    "강퇴 되었습니다." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You have been kicked out."
+          }
+        }
+      }
+    },
     "강퇴 하기" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -536,13 +547,13 @@
         }
       }
     },
-    "사냥꾼" : {
+    "사부님" : {
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hunter"
+            "value" : "Master"
           }
         }
       }
@@ -558,13 +569,13 @@
         }
       }
     },
-    "사부님" : {
+    "사냥꾼" : {
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Master"
+            "value" : "Hunter"
           }
         }
       }
@@ -913,6 +924,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Harmony"
+          }
+        }
+      }
+    },
+    "해당 방에서 강퇴되어 참여할 수 없습니다." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You have been banned from this room and cannot join."
           }
         }
       }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Localizable.xcstrings
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Localizable.xcstrings
@@ -262,19 +262,18 @@
         }
       }
     },
-    "님을 강퇴하시겠습니까?\\n강퇴 시 기존 방에는 영구적으로 재입장이 불가능합니다!" : {
-      "extractionState" : "manual",
+    "님을 강퇴하시겠습니까?\n강퇴 시 기존 방에는 영구적으로 재입장이 불가능합니다!" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Are you sure you want to kick %@ out?\\nOnce kicked, they will not be able to rejoin the room permanently!"
+            "value" : "Are you sure you want to kick %@ out?\nOnce kicked, they will not be able to rejoin the room permanently!"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@님을 강퇴하시겠습니까?\\n강퇴 시 기존 방에는 영구적으로 재입장이 불가능합니다!"
+            "value" : "%@님을 강퇴하시겠습니까?\n강퇴 시 기존 방에는 영구적으로 재입장이 불가능합니다!"
           }
         }
       }
@@ -536,17 +535,6 @@
         }
       }
     },
-    "삶" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Life"
-          }
-        }
-      }
-    },
     "사냥꾼" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -565,6 +553,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Master"
+          }
+        }
+      }
+    },
+    "삶" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Life"
           }
         }
       }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/Alert/ASAlertController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/Alert/ASAlertController.swift
@@ -138,6 +138,7 @@ enum ASAlertText {
         case back
         case permissionDenied
         case kick(playerName: String)
+        case receiveKick
 
         var description: String {
             switch self {
@@ -149,6 +150,7 @@ enum ASAlertText {
                 case .back: "이전 화면으로 돌아가시겠습니까?"
                 case .permissionDenied: "게임을 시작하기 위해서 마이크 권한이 필요해요"
                 case let .kick(playerName): String(format: NSLocalizedString("님을 강퇴하시겠습니까?", comment: ""), playerName)
+                case .receiveKick: "강퇴 되었습니다."
             }
         }
     }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/Alert/ASAlertController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/Alert/ASAlertController.swift
@@ -137,6 +137,7 @@ enum ASAlertText {
         case needMorePlayer
         case back
         case permissionDenied
+        case kick(playerName: String)
 
         var description: String {
             switch self {
@@ -147,6 +148,7 @@ enum ASAlertText {
                 case .needMorePlayer: "알쏭달쏭은 여럿이서 할 수록\n재미있는 게임이에요!\n그래도 하시겠어요?"
                 case .back: "이전 화면으로 돌아가시겠습니까?"
                 case .permissionDenied: "게임을 시작하기 위해서 마이크 권한이 필요해요"
+                case let .kick(playerName): String(format: NSLocalizedString("님을 강퇴하시겠습니까?", comment: ""), playerName)
             }
         }
     }
@@ -159,6 +161,7 @@ enum ASAlertText {
         case keep
         case back
         case setting
+        case kick
 
         var description: String {
             switch self {
@@ -169,6 +172,7 @@ enum ASAlertText {
                 case .keep: "계속 하기"
                 case .back: "뒤로가기"
                 case .setting: "설정 가기"
+                case .kick: "강퇴 하기"
             }
         }
     }
@@ -198,7 +202,7 @@ enum ASAlertText {
                 case .submitMusic: "노래를 전송하는 중..."
                 case .submitHumming: "허밍을 전송하는 중..."
                 case .nextResult: "다음 결과를 가져오는 중..."
-                case . toLobby: "로비로 이동하는 중..."
+                case .toLobby: "로비로 이동하는 중..."
             }
         }
     }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/Alert/ASAlertController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/Alert/ASAlertController.swift
@@ -149,7 +149,7 @@ enum ASAlertText {
                 case .needMorePlayer: "알쏭달쏭은 여럿이서 할 수록\n재미있는 게임이에요!\n그래도 하시겠어요?"
                 case .back: "이전 화면으로 돌아가시겠습니까?"
                 case .permissionDenied: "게임을 시작하기 위해서 마이크 권한이 필요해요"
-                case let .kick(playerName): String(format: NSLocalizedString("님을 강퇴하시겠습니까?", comment: ""), playerName)
+                case let .kick(playerName): String(format: NSLocalizedString("님을 강퇴하시겠습니까?\n강퇴 시 기존 방에는 영구적으로 재입장이 불가능합니다!", comment: ""), playerName)
                 case .receiveKick: "강퇴 되었습니다."
             }
         }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Extensions/UIApplication+topViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Extensions/UIApplication+topViewController.swift
@@ -1,0 +1,22 @@
+import UIKit
+
+extension UIApplication {
+    func topViewController(
+        base: UIViewController? = UIApplication.shared.connectedScenes
+            .compactMap { ($0 as? UIWindowScene)?.keyWindow }
+            .first?.rootViewController
+    ) -> UIViewController? {
+        if let nav = base as? UINavigationController {
+            return topViewController(base: nav.visibleViewController)
+        }
+        if let tab = base as? UITabBarController,
+           let selected = tab.selectedViewController
+        {
+            return topViewController(base: selected)
+        }
+        if let presented = base?.presentedViewController {
+            return topViewController(base: presented)
+        }
+        return base
+    }
+}

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/ASErrors.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/ASErrors.swift
@@ -12,7 +12,7 @@ struct ASErrors: LocalizedError {
         case submitHumming
         case fetchAvatars
         case gameStart, changeMode
-        case authorizeAppleMusic, joinRoom, createRoom
+        case authorizeAppleMusic, joinRoom, createRoom, kickUser
         case submitRehumming
         case changeRecordOrder, navigateToLobby
         case submitMusic, searchMusicOnSelect, randomMusic

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GameNavigationController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GameNavigationController.swift
@@ -41,8 +41,8 @@ final class GameNavigationController: @unchecked Sendable {
         
         gameStateRepository.receiveKickOut()
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] isKickedOut in
-                guard isKickedOut else { return }
+            .filter { $0 }
+            .sink { [weak self] _ in
                 self?.leaveRoom()
                 let alert = SingleButtonAlertController(
                     titleText: .receiveKick) { _ in

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GameNavigationController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GameNavigationController.swift
@@ -38,6 +38,20 @@ final class GameNavigationController: @unchecked Sendable {
                 self?.gameInfo = gameState
             }
             .store(in: &subscriptions)
+        
+        gameStateRepository.receiveKickOut()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isKickedOut in
+                guard isKickedOut else { return }
+                self?.leaveRoom()
+                let alert = SingleButtonAlertController(
+                    titleText: .receiveKick) { _ in
+                    self?.navigationController.popToRootViewController(animated: true)
+                    self?.navigationController.navigationBar.isHidden = true
+                }
+                self?.navigationController.presentAlert(alert)
+            }
+            .store(in: &subscriptions)
     }
 
     private func setupNavigationBar(for viewController: UIViewController) {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyView.swift
@@ -82,7 +82,7 @@ struct LobbyView: View {
                 }
             }
         )
-        if let topVC = UIApplication.shared.topViewController() {
+        if let topVC = UIApplication.shared.topViewController(), topVC is LobbyViewController {
             topVC.presentAlert(alertContrller)
         }
     }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyView.swift
@@ -1,26 +1,43 @@
+import ASEntity
 import SwiftUI
 
 struct LobbyView: View {
     @ObservedObject var viewModel: LobbyViewModel
-    @State var isPresented = false
     @Environment(\.dismiss) var dismiss
     
     var body: some View {
         VStack {
             ScrollView(.horizontal) {
                 HStack(alignment: .top, spacing: 16) {
-                    ForEach(0..<viewModel.playerMaxCount) { index in
+                    ForEach(0 ..< viewModel.playerMaxCount, id: \.self) { index in
                         if index < viewModel.players.count {
                             let player = viewModel.players[index]
-                            ProfileView(
-                                imagePublisher: { url in
-                                    await viewModel.getAvatarData(url: url)
-                                },
-                                name: player.nickname,
-                                isMyId: player.id == viewModel.myId,
-                                isHost: player.id == viewModel.host?.id,
-                                imageUrl: player.avatarUrl
-                            )
+                            if viewModel.isHost, player.id != viewModel.host?.id {
+                                Button {
+                                    presentKickAlert(player: player)
+                                } label: {
+                                    ProfileView(
+                                        imagePublisher: { url in
+                                            await viewModel.getAvatarData(url: url)
+                                        },
+                                        name: player.nickname,
+                                        isMyId: player.id == viewModel.myId,
+                                        isHost: player.id == viewModel.host?.id,
+                                        imageUrl: player.avatarUrl
+                                    )
+                                }
+                                .buttonStyle(PlainButtonStyle())
+                            } else {
+                                ProfileView(
+                                    imagePublisher: { url in
+                                        await viewModel.getAvatarData(url: url)
+                                    },
+                                    name: player.nickname,
+                                    isMyId: player.id == viewModel.myId,
+                                    isHost: player.id == viewModel.host?.id,
+                                    imageUrl: player.avatarUrl
+                                )
+                            }
                         } else {
                             ProfileView(
                                 imagePublisher: { url in
@@ -52,5 +69,21 @@ struct LobbyView: View {
             }
         }
         .background(Color.asLightGray)
+    }
+
+    func presentKickAlert(player: Player) {
+        let alertContrller = DefaultAlertController(
+            titleText: .kick(playerName: player.nickname ?? ""),
+            primaryButtonText: .kick,
+            secondaryButtonText: .cancel,
+            primaryButtonAction: { _ in
+                Task {
+                    try await viewModel.kickUser(userID: player.id)
+                }
+            }
+        )
+        if let topVC = UIApplication.shared.topViewController() {
+            topVC.presentAlert(alertContrller)
+        }
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewModel.swift
@@ -114,4 +114,14 @@ final class LobbyViewModel: ObservableObject, @unchecked Sendable {
             }
         }
     }
+    
+    func kickUser(userID: String) async throws {
+        do {
+            _ = try await roomActionRepository.kickPlayer(roomNumber: roomNumber, userID: userID)
+        } catch {
+            let error = ASErrors(type: .kickUser, reason: error.localizedDescription, file: #file, line: #line)
+            LogHandler.handleError(error)
+            throw error
+        }
+    }
 }

--- a/firebase/functions/api/JoinRoom.js
+++ b/firebase/functions/api/JoinRoom.js
@@ -9,7 +9,7 @@ const { FieldValue } = require('firebase-admin/firestore');
 /**
  * 방 참여를 요청하는 API
  * @param roomNumber - 방 번호
- * @param playerId - 참여자 id
+ * @param userId - 참여자 id
  * @returns playerData
  */
 module.exports.joinRoom = onRequest({ region: 'asia-southeast1' }, async (req, res) => {
@@ -30,6 +30,12 @@ module.exports.joinRoom = onRequest({ region: 'asia-southeast1' }, async (req, r
     }
 
     const roomData = roomSnapshot.data();
+
+    // bannedPlayers 체크: bannedPlayers 배열에 userId가 존재하면 에러 코드 453 반환
+    if (roomData.bannedPlayers && Array.isArray(roomData.bannedPlayers) && roomData.bannedPlayers.includes(userId)) {
+      return res.status(453).json({ error: 'User is banned from this room' });
+    }
+
     const playerExists = roomData.players.some((player) => player.id === userId);
     const inGame = roomData.status !== null;
 

--- a/firebase/functions/api/KickPlayer.js
+++ b/firebase/functions/api/KickPlayer.js
@@ -46,7 +46,7 @@ module.exports.kickPlayer = onRequest({ region: 'asia-southeast1' }, async (req,
       players: updatedPlayers,
     });
 
-    res.status(200).json({ message: 'Player successfully kicked from the room' });
+    res.status(200).json({ success: true });
   } catch (error) {
     console.error('Kick player error:', error);
     res.status(500).json({ error: 'Failed to kick player' });

--- a/firebase/functions/api/KickPlayer.js
+++ b/firebase/functions/api/KickPlayer.js
@@ -1,0 +1,54 @@
+const { onRequest } = require('firebase-functions/v2/https');
+const admin = require('../FirebaseAdmin.js');
+
+/**
+ * 유저 강퇴 API
+ * @param roomNumber - 방 번호
+ * @param hostId - 호스트 ID
+ * @param playerId - 강퇴할 유저 ID
+ * @returns status message
+ */
+module.exports.kickPlayer = onRequest({ region: 'asia-southeast1' }, async (req, res) => {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Only POST requests are accepted' });
+  }
+
+  const { roomNumber, hostId, playerId } = req.body;
+  if (!roomNumber || !hostId || !playerId) {
+    return res.status(400).json({ error: 'Room number, host ID, and player ID are required' });
+  }
+
+  try {
+    const roomRef = admin.firestore().collection('rooms').doc(roomNumber);
+    const roomSnapshot = await roomRef.get();
+
+    if (!roomSnapshot.exists) {
+      return res.status(404).json({ error: 'Room not found' });
+    }
+
+    const roomData = roomSnapshot.data();
+
+    // 요청한 유저가 방의 호스트인지 확인
+    if (roomData.host.id !== hostId) {
+      return res.status(403).json({ error: 'Only the host can kick players' });
+    }
+
+    const players = roomData.players;
+    const playerExists = players.some((player) => player.id === playerId);
+
+    if (!playerExists) {
+      return res.status(404).json({ error: 'Player not found in the room' });
+    }
+
+    // 강퇴할 플레이어를 players 리스트에서 제거
+    const updatedPlayers = players.filter((player) => player.id !== playerId);
+    await roomRef.update({
+      players: updatedPlayers,
+    });
+
+    res.status(200).json({ message: 'Player successfully kicked from the room' });
+  } catch (error) {
+    console.error('Kick player error:', error);
+    res.status(500).json({ error: 'Failed to kick player' });
+  }
+});

--- a/firebase/functions/api/KickPlayer.js
+++ b/firebase/functions/api/KickPlayer.js
@@ -44,6 +44,7 @@ module.exports.kickPlayer = onRequest({ region: 'asia-southeast1' }, async (req,
     const updatedPlayers = players.filter((player) => player.id !== playerId);
     await roomRef.update({
       players: updatedPlayers,
+      bannedPlayers: admin.firestore.FieldValue.arrayUnion(playerId),
     });
 
     res.status(200).json({ success: true });

--- a/firebase/functions/index.js
+++ b/firebase/functions/index.js
@@ -14,6 +14,7 @@ const { submitMusicV2 } = require('./api/SubmitMusicV2.js');
 const { submitAnswerV2 } = require('./api/SubmitAnswerV2.js');
 const { uploadRecordingV2 } = require('./api/UploadRecordV2.js');
 const { uploadRecordingV3 } = require('./api/UploadRecordV3.js');
+const { kickPlayer } = require('./api/KickPlayer.js');
 
 // 방 관련 API
 exports.createRoom = createRoom;
@@ -29,6 +30,7 @@ exports.resetGame = resetGame;
 exports.onRemovePlayer = onRemovePlayer;
 exports.startGame = startGame;
 exports.uploadRecording = uploadRecord;
+exports.kickPlayer = kickPlayer;
 
 exports.V2 = {
   uploadRecording: uploadRecordingV2,


### PR DESCRIPTION
## 필수 리뷰어
- nil

## 관련 이슈

- #14 

## 완료 및 수정 내역

 - [x] : Kick API 추가
 - [x] : Host가 Kick 하는 Alert View 추가
 - [x] : Kick 당한 Player 에게 나오는 Alert View 추가  

## 리뷰 노트
- 지난 회의에서 얘기드렸었던 SwiftUI View 에서 UIKit기반의 Alert 뷰를 Present하기 위해 UIViewControllerRepresentation으로 감싼 Wrapper로 SwiftUI에서 불러오는 방법을 택했었는데, SwiftUI에 랜더링 사이클과 오류가 발생했었습니다.  
  - 이를 UIApplication에서 현재 보여지고있는 ViewController를 가져오고, 해당 ViewController에 PresentAlert하는 방법으로 해결했습니다.
```swift
// LobbyView.swift
func presentKickAlert(player: Player) {
  let alertContrller = DefaultAlertController(
      titleText: .kick(playerName: player.nickname ?? ""),
      primaryButtonText: .kick,
      secondaryButtonText: .cancel,
      primaryButtonAction: { _ in
          Task {
              try await viewModel.kickUser(userID: player.id)
          }
      }
  )
  if let topVC = UIApplication.shared.topViewController() {
      topVC.presentAlert(alertContrller)
  }
}
``` 
- Kick 당한 Player에 대한 처리를 Room에 Player를 삭제시키고, 자기의 Player ID와 비교하여 Kick되었다는 것을 알려주려고 했습니다.
- 위 방법에서 생긴 문제가 있었습니다. 강퇴 당한 후, 다시 해당 방에 접속 시 간헐적으로 다시 들어와질 때도 있고 들어와지지 않는 케이스가 발견되었습니다.
  - 찾아보니.. Firestore Listner가 내부적으로 Cache기능이 있어, 강퇴 당한 방에 대한 Cache가 남아있다는 문제가 생겼었습니다..
  - 이를 캐싱기능을 끄거나 캐시를 비우는 방법을 찾아보려고 했으나 SDK 에서 제공하지 않았습니다. 
  - 결국 database에 bannedPlayer라는 해당 방에서 강퇴당한 PlayerID를 저장하는 방법을 택했습니다.

## 스크린샷 (선택)

![화면 기록 2025-03-19 오후 9 42 33](https://github.com/user-attachments/assets/7c596d79-ab1d-4e0e-a0f6-20a75250e19d)
