### PR TITLE
[refactor] ASButton 구조 개선

### DIFF
--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
@@ -155,3 +155,24 @@ final class ASButton: UIButton {
         }
     }
 }
+
+private extension ASButton {
+    /// 버튼이 눌렸을 때 효과를 적용하는 메서드
+    func applyHighlightEffect() {
+        if isHighlighted {
+            transform = CGAffineTransform(translationX: 3, y: 3)
+            layer.shadowOffset = .zero
+        } else {
+            transform = .identity
+            layer.shadowOffset = CGSize(width: 4, height: 4)
+        }
+    }
+    
+    /// 버튼 초기설정을 담당하는 메서드
+    func setupButton() {
+        setShadow()
+        configurationUpdateHandler = { [weak self] _ in
+            self?.applyHighlightEffect()
+        }
+    }
+}

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
@@ -22,7 +22,7 @@ final class ASButton: UIButton {
     ///   - systemImageName: SF Symbol 이미지를 삽입을 원할 경우 "play.fill" 과 같이 systemName 입력.
     ///   - text: 버튼에 쓰일 텍스트
     ///   - textStyle: 버튼에 쓰일 텍스트 스타일
-    ///   - backgroundColor: UIColor 형태로 색깔 입력.  (ex .asYellow)
+    ///   - backgroundColor: UIColor 형태로 색깔 입력.  (e.g. .asYellow)
     ///   - cornerStyle: 코너 스타일
     ///   - baseForegroundColor: 글씨 컬러
     func setConfiguration(

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
@@ -46,7 +46,6 @@ final class ASButton: UIButton {
     }
     
     /// 버튼의 UI 관련한 Configuration을 설정하는 메서드
-
     func setConfiguration(
         _ type: ASButtonType? = nil
     ) {
@@ -144,15 +143,37 @@ final class ASButton: UIButton {
 private extension ASButton {
     /// Configuration을 적용하는 메서드
     func applyConfiguration() {
-      
+        self.configuration = configurationData?.createConfiguration()
     }
 
     /// 버튼을 비활성화하고 색상을 변경하는 메서드
     func disableButton() {
+        configurationData = ASButtonConfiguration(
+            systemImageName: configurationData?.systemImageName,
+            text: configurationData?.text,
+            textStyle: configurationData?.textStyle ?? .largeTitle,
+            backgroundColor: .systemGray2,
+            cornerStyle: configurationData?.cornerStyle ?? .medium,
+            baseForegroundColor: configurationData?.baseForegroundColor ?? .asBlack,
+            previousBackgroundColor: configuration?.baseBackgroundColor
+        )
+        isEnabled = false
+        applyConfiguration()
     }
 
     /// 버튼을 활성화하고 원래 색상으로 되돌리는 메서드
     func enableButton() {
+        let previousBackgroundColor = configurationData?.previousBackgroundColor
+        configurationData = ASButtonConfiguration(
+            systemImageName: configurationData?.systemImageName,
+            text: configurationData?.text,
+            textStyle: configurationData?.textStyle ?? .largeTitle,
+            backgroundColor: previousBackgroundColor,
+            cornerStyle: configurationData?.cornerStyle ?? .medium,
+            baseForegroundColor: configurationData?.baseForegroundColor ?? .asBlack
+        )
+        isEnabled = true
+        applyConfiguration()
     }
 
     /// 버튼이 눌렸을 때 효과를 적용하는 메서드

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
@@ -89,15 +89,12 @@ final class ASButton: UIButton {
             }
             .store(in: &cancellables)
     }
-
-    func updateButton(_ type: ASButton.ASButtonType) {
-        switch type {
-            case .disabled: disable()
-            case .submitted:
-                setConfiguration(text: type.text)
-                disable()
-            default: setConfiguration(systemImageName: type.systemImage, text: type.text, backgroundColor: type.backgroundColor)
-        }
+    
+    /// 버튼의 활성화 여부를 결정하는 메서드입니다.
+    /// - Parameters:
+    ///    - isEnabled: `true`면 버튼을 활성화하고, `false`면 버튼을 비활성화합니다.
+    func setEnabled(_ isEnabled: Bool) {
+        isEnabled ? enableButton() : disableButton()
     }
 
     enum ASButtonType {
@@ -160,6 +157,19 @@ final class ASButton: UIButton {
 }
 
 private extension ASButton {
+    /// Configuration을 적용하는 메서드
+    func applyConfiguration() {
+      
+    }
+
+    /// 버튼을 비활성화하고 색상을 변경하는 메서드
+    func disableButton() {
+    }
+
+    /// 버튼을 활성화하고 원래 색상으로 되돌리는 메서드
+    func enableButton() {
+    }
+
     /// 버튼이 눌렸을 때 효과를 적용하는 메서드
     func applyHighlightEffect() {
         if isHighlighted {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
@@ -77,14 +77,15 @@ final class ASButton: UIButton {
     }
 
     func bind(
-        to dataSource: Published<Data?>.Publisher
+        to dataSource: Published<Data?>.Publisher,
+        baseBackgroundColor: UIColor = .asGreen
     ) {
         dataSource
             .receive(on: DispatchQueue.main)
             .compactMap { $0 }
             .sink { [weak self] data in
+                self?.configuration?.baseBackgroundColor = baseBackgroundColor
                 self?.isEnabled = true
-                self?.configuration?.baseBackgroundColor = .asGreen
             }
             .store(in: &cancellables)
     }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
@@ -81,8 +81,8 @@ final class ASButton: UIButton {
     ) {
         dataSource
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] newHumming in
-                if newHumming == nil { return }
+            .compactMap { $0 }
+            .sink { [weak self] data in
                 self?.isEnabled = true
                 self?.configuration?.baseBackgroundColor = .asGreen
             }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
@@ -4,6 +4,7 @@ import UIKit
 
 /// 버튼의 동작을 관리
 final class ASButton: UIButton {
+    private var configurationData: ASButtonConfiguration?
     private var cancellables = Set<AnyCancellable>()
 
     init() {
@@ -29,58 +30,37 @@ final class ASButton: UIButton {
         text: String? = nil,
         textStyle: UIFont.TextStyle = .largeTitle,
         backgroundColor: UIColor? = nil,
-        cornerStyle: UIButton.Configuration.CornerStyle = .medium
+        cornerStyle: UIButton.Configuration.CornerStyle = .medium,
+        baseForegroundColor: UIColor = .asBlack
     ) {
-        var config = UIButton.Configuration.gray()
-        config.baseForegroundColor = .asBlack
-        config.background.strokeColor = .black
-        config.background.strokeWidth = 3
-        
-        if let systemImageName {
-            config.imagePlacement = .leading
-            config.image = UIImage(systemName: systemImageName)
-            config.imagePadding = 10
-            let imageConfig = UIImage.SymbolConfiguration(pointSize: 20, weight: .heavy)
-            config.preferredSymbolConfigurationForImage = imageConfig
-        }
-        
-        if let backgroundColor {
-            config.baseBackgroundColor = backgroundColor
-        }
+        configurationData = ASButtonConfiguration(
+            systemImageName: systemImageName,
+            text: text ?? configurationData?.text,
+            textStyle: textStyle,
+            backgroundColor: backgroundColor,
+            cornerStyle: cornerStyle,
+            baseForegroundColor: baseForegroundColor
+        )
 
-        if let text {
-            var titleAttr = AttributedString(text)
-            titleAttr.font = UIFont.font(forTextStyle: textStyle)
-            config.attributedTitle = titleAttr
-        }
-
-        config.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 12)
-        config.cornerStyle = cornerStyle
-
-        setShadow()
-        
-        config.background.backgroundColorTransformer = UIConfigurationColorTransformer { color in
-            color.withAlphaComponent(1.0)
-        }
-
-        configurationUpdateHandler = { [weak self] _ in
-            guard let self else { return }
-            if isHighlighted {
-                transform = CGAffineTransform(translationX: 3, y: 3)
-                layer.shadowOffset = .zero
-            } else {
-                transform = .identity
-                layer.shadowOffset = CGSize(width: 4, height: 4)
-            }
-        }
-        configuration = config
+        applyConfiguration()
     }
+    
+    /// 버튼의 UI 관련한 Configuration을 설정하는 메서드
 
-    private func disable(_ color: UIColor = .systemGray2) {
-        configuration?.baseBackgroundColor = color
-        isEnabled = false
+    func setConfiguration(
+        _ type: ASButtonType? = nil
+    ) {
+        configurationData = ASButtonConfiguration(
+            systemImageName: type?.systemImage,
+            text: type?.text,
+            textStyle: type?.textStyle ?? .largeTitle,
+            backgroundColor: type?.backgroundColor,
+            cornerStyle: type?.cornerStyle ?? .medium
+        )
+
+        applyConfiguration()
     }
-
+    
     func bind(
         to dataSource: Published<Data?>.Publisher,
         baseBackgroundColor: UIColor = .asGreen

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
@@ -74,11 +74,18 @@ final class ASButton: UIButton {
             .store(in: &cancellables)
     }
     
-    /// 버튼의 활성화 여부를 결정하는 메서드입니다.
-    /// - Parameters:
-    ///    - isEnabled: `true`면 버튼을 활성화하고, `false`면 버튼을 비활성화합니다.
-    func setEnabled(_ isEnabled: Bool) {
-        isEnabled ? enableButton() : disableButton()
+    /// 버튼을 비활성화하면서 스타일을 변경하는 메서드입니다.
+    func setDisabledState() {
+        configurationData = ASButtonConfiguration(
+            systemImageName: configurationData?.systemImageName,
+            text: configurationData?.text,
+            textStyle: configurationData?.textStyle ?? .largeTitle,
+            backgroundColor: .systemGray2,
+            cornerStyle: configurationData?.cornerStyle ?? .medium,
+            baseForegroundColor: configurationData?.baseForegroundColor ?? .asBlack
+        )
+        isEnabled = false
+        applyConfiguration()
     }
 
     enum ASButtonType {
@@ -144,36 +151,6 @@ private extension ASButton {
     /// Configuration을 적용하는 메서드
     func applyConfiguration() {
         self.configuration = configurationData?.createConfiguration()
-    }
-
-    /// 버튼을 비활성화하고 색상을 변경하는 메서드
-    func disableButton() {
-        configurationData = ASButtonConfiguration(
-            systemImageName: configurationData?.systemImageName,
-            text: configurationData?.text,
-            textStyle: configurationData?.textStyle ?? .largeTitle,
-            backgroundColor: .systemGray2,
-            cornerStyle: configurationData?.cornerStyle ?? .medium,
-            baseForegroundColor: configurationData?.baseForegroundColor ?? .asBlack,
-            previousBackgroundColor: configuration?.baseBackgroundColor
-        )
-        isEnabled = false
-        applyConfiguration()
-    }
-
-    /// 버튼을 활성화하고 원래 색상으로 되돌리는 메서드
-    func enableButton() {
-        let previousBackgroundColor = configurationData?.previousBackgroundColor
-        configurationData = ASButtonConfiguration(
-            systemImageName: configurationData?.systemImageName,
-            text: configurationData?.text,
-            textStyle: configurationData?.textStyle ?? .largeTitle,
-            backgroundColor: previousBackgroundColor,
-            cornerStyle: configurationData?.cornerStyle ?? .medium,
-            baseForegroundColor: configurationData?.baseForegroundColor ?? .asBlack
-        )
-        isEnabled = true
-        applyConfiguration()
     }
 
     /// 버튼이 눌렸을 때 효과를 적용하는 메서드

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
@@ -101,9 +101,7 @@ final class ASButton: UIButton {
     }
 
     enum ASButtonType {
-        case disabled
         case needMorePlayers
-        case idle(String, UIColor?)
         case startRecord, recording, reRecord
         case complete
         case submit, submitted
@@ -111,12 +109,10 @@ final class ASButton: UIButton {
         case startWaiting, endWaiting
         case next
         case nextResultWaiting
-
-        var text: String? {
+        
+        var text: String {
             switch self {
-                case .disabled: nil
                 case .needMorePlayers: String(localized: "게임 인원 부족")
-                case let .idle(string, _): string
                 case .startRecord: String(localized: "녹음하기")
                 case .recording: String(localized: "녹음중")
                 case .reRecord: String(localized: "재녹음")
@@ -142,7 +138,6 @@ final class ASButton: UIButton {
         var backgroundColor: UIColor? {
             switch self {
                 case .needMorePlayers: .asOrange
-                case let .idle(_, color): color
                 case .startRecord: .systemRed
                 case .recording: .asLightRed
                 case .reRecord: .asOrange
@@ -152,6 +147,14 @@ final class ASButton: UIButton {
                 case .endWaiting, .nextResultWaiting: .systemGray2
                 default: nil
             }
+        }
+        
+        var textStyle: UIFont.TextStyle {
+            .largeTitle
+        }
+
+        var cornerStyle: UIButton.Configuration.CornerStyle {
+            .medium
         }
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
@@ -2,6 +2,7 @@ import Combine
 import SwiftUI
 import UIKit
 
+/// 버튼의 동작을 관리
 final class ASButton: UIButton {
     private var cancellables = Set<AnyCancellable>()
 
@@ -20,7 +21,9 @@ final class ASButton: UIButton {
     ///   - systemImageName: SF Symbol 이미지를 삽입을 원할 경우 "play.fill" 과 같이 systemName 입력.
     ///   - text: 버튼에 쓰일 텍스트
     ///   - textStyle: 버튼에 쓰일 텍스트 스타일
-    ///   - backgroundColor: UIColor 형태로 색깔 입력.  (ex) .asYellow)
+    ///   - backgroundColor: UIColor 형태로 색깔 입력.  (ex .asYellow)
+    ///   - cornerStyle: 코너 스타일
+    ///   - baseForegroundColor: 글씨 컬러
     func setConfiguration(
         systemImageName: String? = nil,
         text: String? = nil,

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
@@ -7,10 +7,12 @@ final class ASButton: UIButton {
 
     init() {
         super.init(frame: .zero)
+        setupButton()
     }
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+        setupButton()
     }
 
     /// 버튼의 UI 관련한 Configuration을 설정하는 메서드

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButtonConfiguration.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButtonConfiguration.swift
@@ -1,0 +1,67 @@
+import UIKit
+
+extension ASButton {
+    /// ASButton의 스타일 및 설정 정보를 관리하는 구조체
+    struct ASButtonConfiguration {
+        let systemImageName: String?
+        let text: String?
+        let textStyle: UIFont.TextStyle
+        let backgroundColor: UIColor?
+        let cornerStyle: UIButton.Configuration.CornerStyle
+        let baseForegroundColor: UIColor
+        var previousBackgroundColor: UIColor? = nil
+        
+        init(
+            systemImageName: String? = nil,
+            text: String? = nil,
+            textStyle: UIFont.TextStyle = .largeTitle,
+            backgroundColor: UIColor? = nil,
+            cornerStyle: UIButton.Configuration.CornerStyle = .medium,
+            baseForegroundColor: UIColor = .asBlack,
+            previousBackgroundColor: UIColor? = nil
+        ) {
+            self.systemImageName = systemImageName
+            self.text = text
+            self.backgroundColor = backgroundColor
+            self.textStyle = textStyle
+            self.cornerStyle = cornerStyle
+            self.baseForegroundColor = baseForegroundColor
+            self.previousBackgroundColor = previousBackgroundColor
+        }
+        
+        /// 버튼의 스타일을 만드는 메소드
+        func createConfiguration() -> UIButton.Configuration {
+            var config = UIButton.Configuration.gray()
+            config.baseForegroundColor = baseForegroundColor
+            config.background.strokeColor = .black
+            config.background.strokeWidth = 3
+            
+            if let systemImageName {
+                config.imagePlacement = .leading
+                config.image = UIImage(systemName: systemImageName)
+                config.imagePadding = 10
+                let imageConfig = UIImage.SymbolConfiguration(pointSize: 20, weight: .heavy)
+                config.preferredSymbolConfigurationForImage = imageConfig
+            }
+            
+            if let backgroundColor {
+                config.baseBackgroundColor = backgroundColor
+            }
+            
+            if let text {
+                var titleAttr = AttributedString(text)
+                titleAttr.font = UIFont.font(forTextStyle: textStyle)
+                config.attributedTitle = titleAttr
+            }
+            
+            config.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 12)
+            config.cornerStyle = cornerStyle
+            
+            config.background.backgroundColorTransformer = UIConfigurationColorTransformer { color in
+                color.withAlphaComponent(1.0)
+            }
+            
+            return config
+        }
+    }
+}

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButtonConfiguration.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButtonConfiguration.swift
@@ -9,7 +9,6 @@ extension ASButton {
         let backgroundColor: UIColor?
         let cornerStyle: UIButton.Configuration.CornerStyle
         let baseForegroundColor: UIColor
-        var previousBackgroundColor: UIColor? = nil
         
         init(
             systemImageName: String? = nil,
@@ -17,8 +16,7 @@ extension ASButton {
             textStyle: UIFont.TextStyle = .largeTitle,
             backgroundColor: UIColor? = nil,
             cornerStyle: UIButton.Configuration.CornerStyle = .medium,
-            baseForegroundColor: UIColor = .asBlack,
-            previousBackgroundColor: UIColor? = nil
+            baseForegroundColor: UIColor = .asBlack
         ) {
             self.systemImageName = systemImageName
             self.text = text
@@ -26,7 +24,6 @@ extension ASButton {
             self.textStyle = textStyle
             self.cornerStyle = cornerStyle
             self.baseForegroundColor = baseForegroundColor
-            self.previousBackgroundColor = previousBackgroundColor
         }
         
         /// 버튼의 스타일을 만드는 메소드

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewController.swift
@@ -43,7 +43,7 @@ final class HummingViewController: UIViewController {
     private func setupUI() {
         recordButton.setConfiguration(.startRecord)
         submitButton.setConfiguration(.submit)
-        submitButton.setEnabled(false)
+        submitButton.setDisabledState()
         buttonStack.axis = .horizontal
         buttonStack.spacing = 16
         buttonStack.addArrangedSubview(recordButton)
@@ -116,8 +116,8 @@ final class HummingViewController: UIViewController {
         progressBar.cancelCompletion()
         viewModel.didTappedSubmitButton()
         submitButton.setConfiguration(.submitted)
-        submitButton.setEnabled(false)
-        recordButton.setEnabled(false)
+        submitButton.setDisabledState()
+        recordButton.setDisabledState()
     }
 }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewController.swift
@@ -34,16 +34,16 @@ final class HummingViewController: UIViewController {
         musicPanel.bind(to: viewModel.$music)
         hummingPanel.bind(to: viewModel.$isRecording)
         hummingPanel.onRecordingFinished = { [weak self] recordedData in
-            self?.recordButton.updateButton(.reRecord)
+            self?.recordButton.setConfiguration(.reRecord)
             self?.viewModel.didRecordingFinished(recordedData)
         }
         submitButton.bind(to: viewModel.$recordedData)
     }
 
     private func setupUI() {
-        recordButton.updateButton(.startRecord)
-        submitButton.updateButton(.submit)
-        submitButton.updateButton(.disabled)
+        recordButton.setConfiguration(.startRecord)
+        submitButton.setConfiguration(.submit)
+        submitButton.setEnabled(false)
         buttonStack.axis = .horizontal
         buttonStack.spacing = 16
         buttonStack.addArrangedSubview(recordButton)
@@ -59,7 +59,7 @@ final class HummingViewController: UIViewController {
 
     private func setAction() {
         recordButton.addAction(UIAction { [weak self] _ in
-            self?.recordButton.updateButton(.recording)
+            self?.recordButton.setConfiguration(.recording)
             self?.viewModel.didTappedRecordButton()
         },
         for: .touchUpInside)
@@ -115,8 +115,9 @@ final class HummingViewController: UIViewController {
     private func submitHumming() async throws {
         progressBar.cancelCompletion()
         viewModel.didTappedSubmitButton()
-        submitButton.updateButton(.submitted)
-        recordButton.updateButton(.disabled)
+        submitButton.setConfiguration(.submitted)
+        submitButton.setEnabled(false)
+        recordButton.setEnabled(false)
     }
 }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
@@ -48,12 +48,12 @@ final class LobbyViewController: UIViewController {
                     }
                     else {
                         self?.startButton.setConfiguration(.needMorePlayers)
-                        self?.startButton.setEnabled(false)
+                        self?.startButton.setDisabledState()
                     }
                 }
                 else {
                     self?.startButton.setConfiguration(.startWaiting)
-                    self?.startButton.setEnabled(false)
+                    self?.startButton.setDisabledState()
                 }
             }
             .store(in: &cancellables)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
@@ -43,17 +43,17 @@ final class LobbyViewController: UIViewController {
             .sink { [weak self] canBeginGame, isHost in
                 if isHost {
                     if canBeginGame {
-                        self?.startButton.updateButton(.startGame)
+                        self?.startButton.setConfiguration(.startGame)
                         self?.startButton.isEnabled = true
                     }
                     else {
-                        self?.startButton.updateButton(.needMorePlayers)
-                        self?.startButton.updateButton(.disabled)
+                        self?.startButton.setConfiguration(.needMorePlayers)
+                        self?.startButton.setEnabled(false)
                     }
                 }
                 else {
-                    self?.startButton.updateButton(.startWaiting)
-                    self?.startButton.updateButton(.disabled)
+                    self?.startButton.setConfiguration(.startWaiting)
+                    self?.startButton.setEnabled(false)
                 }
             }
             .store(in: &cancellables)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingViewController.swift
@@ -47,7 +47,7 @@ final class RehummingViewController: UIViewController {
     private func setupUI() {
         recordButton.setConfiguration(.startRecord)
         submitButton.setConfiguration(.submit)
-        submitButton.setEnabled(false)
+        submitButton.setDisabledState()
         buttonStack.axis = .horizontal
         buttonStack.spacing = 16
         buttonStack.addArrangedSubview(recordButton)
@@ -121,8 +121,8 @@ final class RehummingViewController: UIViewController {
             progressBar.cancelCompletion()
             try await viewModel.submitHumming()
             submitButton.setConfiguration(.submitted)
-            submitButton.setEnabled(false)
-            recordButton.setEnabled(false)
+            submitButton.setDisabledState()
+            recordButton.setDisabledState()
         } catch {
             throw error
         }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingViewController.swift
@@ -38,16 +38,16 @@ final class RehummingViewController: UIViewController {
         musicPanel.bind(to: viewModel.$music)
         hummingPanel.bind(to: viewModel.$isRecording)
         hummingPanel.onRecordingFinished = { [weak self] recordedData in
-            self?.recordButton.updateButton(.reRecord)
+            self?.recordButton.setConfiguration(.reRecord)
             self?.viewModel.updateRecordedData(with: recordedData)
         }
         submitButton.bind(to: viewModel.$recordedData)
     }
 
     private func setupUI() {
-        recordButton.updateButton(.idle("녹음하기", .systemRed))
-        submitButton.updateButton(.submit)
-        submitButton.updateButton(.disabled)
+        recordButton.setConfiguration(.startRecord)
+        submitButton.setConfiguration(.submit)
+        submitButton.setEnabled(false)
         buttonStack.axis = .horizontal
         buttonStack.spacing = 16
         buttonStack.addArrangedSubview(recordButton)
@@ -63,7 +63,7 @@ final class RehummingViewController: UIViewController {
 
     private func setAction() {
         recordButton.addAction(UIAction { [weak self] _ in
-            self?.recordButton.updateButton(.recording)
+            self?.recordButton.setConfiguration(.recording)
             self?.viewModel.startRecording()
         },
         for: .touchUpInside)
@@ -120,8 +120,9 @@ final class RehummingViewController: UIViewController {
         do {
             progressBar.cancelCompletion()
             try await viewModel.submitHumming()
-            submitButton.updateButton(.submitted)
-            recordButton.updateButton(.disabled)
+            submitButton.setConfiguration(.submitted)
+            submitButton.setEnabled(false)
+            recordButton.setEnabled(false)
         } catch {
             throw error
         }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewController.swift
@@ -60,7 +60,7 @@ class HummingResultViewController: UIViewController {
         viewModel?.isHost == true
         ? nextButton.setConfiguration(.next)
         : nextButton.setConfiguration(.nextResultWaiting)
-        nextButton.setEnabled(false)
+        nextButton.setDisabledState()
     }
 
     private func setAction() {
@@ -126,7 +126,7 @@ class HummingResultViewController: UIViewController {
                 }, for: .touchUpInside)
             }
         } else {
-            nextButton.setEnabled(false)
+            nextButton.setDisabledState()
         }
     }
     
@@ -159,7 +159,7 @@ class HummingResultViewController: UIViewController {
                         self?.showLobbyLoading()
                     }, for: .touchUpInside)
                 } else {
-                    self?.nextButton.setEnabled(false)
+                    self?.nextButton.setDisabledState()
                 }
             }
             .store(in: &cancellables)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewController.swift
@@ -58,9 +58,9 @@ class HummingResultViewController: UIViewController {
 
     private func setButton() {
         viewModel?.isHost == true
-        ? nextButton.updateButton(.next)
-        : nextButton.updateButton(.nextResultWaiting)
-        nextButton.updateButton(.disabled)
+        ? nextButton.setConfiguration(.next)
+        : nextButton.setConfiguration(.nextResultWaiting)
+        nextButton.setEnabled(false)
     }
 
     private func setAction() {
@@ -116,9 +116,9 @@ class HummingResultViewController: UIViewController {
     private func changeButton(_ phase: ResultPhase) {
         if case .none = phase {
             if viewModel?.totalResult.isEmpty == true {
-                nextButton.updateButton(.complete)
+                nextButton.setConfiguration(.complete)
             } else {
-                nextButton.updateButton(.next)
+                nextButton.setConfiguration(.next)
                 nextButton.isEnabled = true
                 nextButton.removeTarget(nil, action: nil, for: .touchUpInside)
                 nextButton.addAction(UIAction { _ in
@@ -126,7 +126,7 @@ class HummingResultViewController: UIViewController {
                 }, for: .touchUpInside)
             }
         } else {
-            nextButton.updateButton(.disabled)
+            nextButton.setEnabled(false)
         }
     }
     
@@ -150,7 +150,7 @@ class HummingResultViewController: UIViewController {
             .sink { [weak self] canEndGame in
                 if canEndGame {
                     guard viewModel.isHost else {
-                        self?.nextButton.updateButton(.endWaiting)
+                        self?.nextButton.setConfiguration(.endWaiting)
                         return
                     }
                     self?.nextButton.isEnabled = true
@@ -159,7 +159,7 @@ class HummingResultViewController: UIViewController {
                         self?.showLobbyLoading()
                     }, for: .touchUpInside)
                 } else {
-                    self?.nextButton.updateButton(.disabled)
+                    self?.nextButton.setEnabled(false)
                 }
             }
             .store(in: &cancellables)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewController.swift
@@ -38,7 +38,7 @@ final class SelectMusicViewController: UIViewController {
     private func setupUI() {
         view.backgroundColor = .asLightGray
         submitButton.setConfiguration(text: String(localized: "선택 완료"), backgroundColor: .asGreen)
-        submitButton.updateButton(.disabled)
+        submitButton.setEnabled(false)
         let musicView = SelectMusicView(viewModel: viewModel)
         selectMusicView = UIHostingController(rootView: musicView)
         
@@ -102,7 +102,8 @@ final class SelectMusicViewController: UIViewController {
             viewModel.stopMusic()
             progressBar.cancelCompletion()
             try await viewModel.submitMusic()
-            submitButton.updateButton(.submitted)
+            submitButton.setConfiguration(.submitted)
+            submitButton.setEnabled(false)
         } catch {
             throw error
         }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewController.swift
@@ -38,7 +38,7 @@ final class SelectMusicViewController: UIViewController {
     private func setupUI() {
         view.backgroundColor = .asLightGray
         submitButton.setConfiguration(text: String(localized: "선택 완료"), backgroundColor: .asGreen)
-        submitButton.setEnabled(false)
+        submitButton.setDisabledState()
         let musicView = SelectMusicView(viewModel: viewModel)
         selectMusicView = UIHostingController(rootView: musicView)
         
@@ -103,7 +103,7 @@ final class SelectMusicViewController: UIViewController {
             progressBar.cancelCompletion()
             try await viewModel.submitMusic()
             submitButton.setConfiguration(.submitted)
-            submitButton.setEnabled(false)
+            submitButton.setDisabledState()
         } catch {
             throw error
         }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewController.swift
@@ -47,7 +47,7 @@ final class SubmitAnswerViewController: UIViewController {
     private func setupUI() {
         selectAnswerButton.setConfiguration(text: String(localized: "정답 선택"), backgroundColor: .asLightSky)
         submitButton.setConfiguration(text: String(localized: "정답 제출"), backgroundColor: .asLightGray)
-        submitButton.setEnabled(false)
+        submitButton.setDisabledState()
         buttonStack.axis = .horizontal
         buttonStack.spacing = 16
         buttonStack.addArrangedSubview(selectAnswerButton)
@@ -107,8 +107,8 @@ final class SubmitAnswerViewController: UIViewController {
             progressBar.cancelCompletion()
             try await viewModel.submitAnswer()
             submitButton.setConfiguration(.submitted)
-            submitButton.setEnabled(false)
-            selectAnswerButton.setEnabled(false)
+            submitButton.setDisabledState()
+            selectAnswerButton.setDisabledState()
         } catch {
             throw error
         }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewController.swift
@@ -47,7 +47,7 @@ final class SubmitAnswerViewController: UIViewController {
     private func setupUI() {
         selectAnswerButton.setConfiguration(text: String(localized: "정답 선택"), backgroundColor: .asLightSky)
         submitButton.setConfiguration(text: String(localized: "정답 제출"), backgroundColor: .asLightGray)
-        submitButton.updateButton(.disabled)
+        submitButton.setEnabled(false)
         buttonStack.axis = .horizontal
         buttonStack.spacing = 16
         buttonStack.addArrangedSubview(selectAnswerButton)
@@ -106,8 +106,9 @@ final class SubmitAnswerViewController: UIViewController {
             viewModel.stopMusic()
             progressBar.cancelCompletion()
             try await viewModel.submitAnswer()
-            submitButton.updateButton(.submitted)
-            selectAnswerButton.updateButton(.disabled)
+            submitButton.setConfiguration(.submitted)
+            submitButton.setEnabled(false)
+            selectAnswerButton.setEnabled(false)
         } catch {
             throw error
         }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Tutorial/Humming/HummingTutorialViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Tutorial/Humming/HummingTutorialViewController.swift
@@ -69,7 +69,7 @@ final class HummingTutorialViewController: UIViewController {
 
         recordButton.setConfiguration(.startRecord)
         submitButton.setConfiguration(.submit)
-        submitButton.setEnabled(false)
+        submitButton.setDisabledState()
 
         buttonStack.axis = .horizontal
         buttonStack.spacing = 16

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Tutorial/Humming/HummingTutorialViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Tutorial/Humming/HummingTutorialViewController.swift
@@ -57,7 +57,7 @@ final class HummingTutorialViewController: UIViewController {
         musicPanel.bind(to: viewModel.$panelData)
         hummingPanel.bind(to: viewModel.$isRecording)
         hummingPanel.onRecordingFinished = { [weak self] data in
-            self?.recordButton.updateButton(.reRecord)
+            self?.recordButton.setConfiguration(.reRecord)
             self?.viewModel.recordedData = data
         }
         submitButton.bind(to: viewModel.$recordedData)
@@ -67,9 +67,9 @@ final class HummingTutorialViewController: UIViewController {
         view.backgroundColor = .asLightGray
         title = "허밍"
 
-        recordButton.updateButton(.startRecord)
-        submitButton.updateButton(.submit)
-        submitButton.updateButton(.disabled)
+        recordButton.setConfiguration(.startRecord)
+        submitButton.setConfiguration(.submit)
+        submitButton.setEnabled(false)
 
         buttonStack.axis = .horizontal
         buttonStack.spacing = 16
@@ -147,7 +147,7 @@ final class HummingTutorialViewController: UIViewController {
 
     private func setupAction() {
         recordButton.addAction(UIAction { [weak self] _ in
-            self?.recordButton.updateButton(.recording)
+            self?.recordButton.setConfiguration(.recording)
             self?.viewModel.isRecording = true
         }, for: .touchUpInside)
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Tutorial/Rehumming/RehummingTutorialViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Tutorial/Rehumming/RehummingTutorialViewController.swift
@@ -79,7 +79,7 @@ final class RehummingTutorialViewController: UIViewController {
 
         recordButton.setConfiguration(.startRecord)
         submitButton.setConfiguration(.submit)
-        submitButton.setEnabled(false)
+        submitButton.setDisabledState()
 
         buttonStack.axis = .horizontal
         buttonStack.spacing = 16

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Tutorial/Rehumming/RehummingTutorialViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Tutorial/Rehumming/RehummingTutorialViewController.swift
@@ -67,7 +67,7 @@ final class RehummingTutorialViewController: UIViewController {
         musicPanel.bind(to: viewModel.$panelData)
         hummingPanel.bind(to: viewModel.$isRecording)
         hummingPanel.onRecordingFinished = { [weak self] data in
-            self?.recordButton.updateButton(.reRecord)
+            self?.recordButton.setConfiguration(.reRecord)
             self?.viewModel.recordedData = data
         }
         submitButton.bind(to: viewModel.$recordedData)
@@ -77,9 +77,9 @@ final class RehummingTutorialViewController: UIViewController {
         view.backgroundColor = .asLightGray
         title = "리허밍"
 
-        recordButton.updateButton(.startRecord)
-        submitButton.updateButton(.submit)
-        submitButton.updateButton(.disabled)
+        recordButton.setConfiguration(.startRecord)
+        submitButton.setConfiguration(.submit)
+        submitButton.setEnabled(false)
 
         buttonStack.axis = .horizontal
         buttonStack.spacing = 16
@@ -157,7 +157,7 @@ final class RehummingTutorialViewController: UIViewController {
 
     private func setupAction() {
         recordButton.addAction(UIAction { [weak self] _ in
-            self?.recordButton.updateButton(.recording)
+            self?.recordButton.setConfiguration(.recording)
             self?.viewModel.isRecording = true
         }, for: .touchUpInside)
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Tutorial/Result/HummingResultTutorialViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Tutorial/Result/HummingResultTutorialViewController.swift
@@ -185,7 +185,7 @@ final class HummingResultTutorialViewController: UIViewController {
                 viewModel.updateResult()
             }, for: .touchUpInside)
         } else {
-            nextButton.setEnabled(false)
+            nextButton.setDisabledState()
         }
     }
     
@@ -195,7 +195,7 @@ final class HummingResultTutorialViewController: UIViewController {
             text: String(localized: "다음으로"),
             backgroundColor: .asMint
         )
-        nextButton.setEnabled(false)
+        nextButton.setDisabledState()
     }
 }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Tutorial/Result/HummingResultTutorialViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Tutorial/Result/HummingResultTutorialViewController.swift
@@ -185,7 +185,7 @@ final class HummingResultTutorialViewController: UIViewController {
                 viewModel.updateResult()
             }, for: .touchUpInside)
         } else {
-            nextButton.updateButton(.disabled)
+            nextButton.setEnabled(false)
         }
     }
     
@@ -195,7 +195,7 @@ final class HummingResultTutorialViewController: UIViewController {
             text: String(localized: "다음으로"),
             backgroundColor: .asMint
         )
-        nextButton.updateButton(.disabled)
+        nextButton.setEnabled(false)
     }
 }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Tutorial/SelectMusic/SelectMusicTutorialViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Tutorial/SelectMusic/SelectMusicTutorialViewController.swift
@@ -80,13 +80,13 @@ final class SelectMusicTutorialViewController: UIViewController {
 
         let musicView = SelectMusicTutorialView { [weak self] music in
             self?.selectedMusic = music
-            self?.submitButton.updateButton(.submit)
+            self?.submitButton.setConfiguration(.submit)
             self?.submitButton.isEnabled = true
         }
         selectMusicView = UIHostingController(rootView: musicView)
 
         submitButton.setConfiguration(text: String(localized: "선택 완료"), backgroundColor: .asGreen)
-        submitButton.updateButton(.disabled)
+        submitButton.setEnabled(false)
 
         view.addSubview(progressBar)
         view.addSubview(selectMusicView.view)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Tutorial/SelectMusic/SelectMusicTutorialViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Tutorial/SelectMusic/SelectMusicTutorialViewController.swift
@@ -86,7 +86,7 @@ final class SelectMusicTutorialViewController: UIViewController {
         selectMusicView = UIHostingController(rootView: musicView)
 
         submitButton.setConfiguration(text: String(localized: "선택 완료"), backgroundColor: .asGreen)
-        submitButton.setEnabled(false)
+        submitButton.setDisabledState()
 
         view.addSubview(progressBar)
         view.addSubview(selectMusicView.view)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Tutorial/SubmitAnswer/SubmitAnswerTutorialViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Tutorial/SubmitAnswer/SubmitAnswerTutorialViewController.swift
@@ -69,7 +69,7 @@ final class SubmitAnswerTutorialViewController: UIViewController {
         
         selectAnswerButton.setConfiguration(text: String(localized: "정답 선택"), backgroundColor: .asLightSky)
         submitButton.setConfiguration(text: String(localized: "정답 제출"), backgroundColor: .asLightGray)
-        submitButton.updateButton(.disabled)
+        submitButton.setEnabled(false)
         buttonStack.axis = .horizontal
         buttonStack.spacing = 16
         buttonStack.addArrangedSubview(selectAnswerButton)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Tutorial/SubmitAnswer/SubmitAnswerTutorialViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Tutorial/SubmitAnswer/SubmitAnswerTutorialViewController.swift
@@ -69,7 +69,7 @@ final class SubmitAnswerTutorialViewController: UIViewController {
         
         selectAnswerButton.setConfiguration(text: String(localized: "정답 선택"), backgroundColor: .asLightSky)
         submitButton.setConfiguration(text: String(localized: "정답 제출"), backgroundColor: .asLightGray)
-        submitButton.setEnabled(false)
+        submitButton.setDisabledState()
         buttonStack.axis = .horizontal
         buttonStack.spacing = 16
         buttonStack.addArrangedSubview(selectAnswerButton)


### PR DESCRIPTION
## 필수 리뷰어
- @Sonny-Kor 
- @moral-life 
- @around-forest 
- @hyunjuntyler 

## 관련 이슈

- #31 

## 완료 및 수정 내역

 - [x] ASButton 개선

## 리뷰 노트

## 🧐 문제 1: 버튼 설정 방식의 불일치

현재 코드에서 일부 버튼은 아래처럼 updateButton을 사용해서 버튼을 설정하고 

```swift
private func setupUI() {
    recordButton.updateButton(.startRecord)
    submitButton.updateButton(.submit)
    //생략
}
```

일부는 setConfiguration로 사용하고 있었습니다

```swift
private func setupUI() {
    inviteButton.setConfiguration(
        systemImageName: "link",
        text: String(localized: "초대하기!"),
        backgroundColor: .asYellow
    )

    startButton.setConfiguration(
        systemImageName: "play.fill",
        text: String(localized: "시작하기!"),
        backgroundColor: .asMint
    )
    //생략
}
```
이렇게 혼용해서 사용이 가능하면 일관성이 깨진다고 판단했습니다.

그래서 일관성 있는 방식으로 통합하여 코드의 일관성과 유지보수성을 높이고 싶었습니다.

## 🧐 문제2: 버튼 추가 시 enum 수정이 필요함

기존에 setConfiguration는 버튼에 대한 각각의 설정(텍스트문구 등)을 받고 있고

```swift
func setConfiguration(
    systemImageName: String? = nil,
    text: String? = nil,
    textStyle: UIFont.TextStyle = .largeTitle,
    backgroundColor: UIColor? = nil,
    cornerStyle: UIButton.Configuration.CornerStyle = .medium
) 
```

updateButton는 enum을 받고있었습니다.

그리고 updateButton은 내부적으로 다시 setConfiguration를 호출하고 있습니다.

```swift
func updateButton(_ type: ASButton.ASButtonType) {
    switch type {
        case .disabled: disable()
        case .submitted:
            setConfiguration(text: type.text)
            disable()
        default: setConfiguration(systemImageName: type.systemImage, text: type.text, backgroundColor: type.backgroundColor)
    }
}
```

그래서 버튼을 만들고 updateButton을 사용하기 위해서는 반드시 enum case에 추가해줘야했습니다.

버튼이 생길때마다 기존의 enum을 ⭐️반드시⭐️ 수정해야하는 구조는 좋지 못하다고 생각해서 ⭐️반드시⭐️라는 제약조건을 없애서 확장성을 높이고 싶었습니다.

## 💡개선(해결) 1,2: 오버로딩

현재 외부에서 사용하는 방식은 enum을 받거나 각 정보를 받거나 둘 중 하나입니다.
외부에서 사용하는 방식이 많이 변경된다면 ⭐️개선⭐️이 아니라 새로 만드는거랑 다름없디고 생각했기에 외부에서 사용하는 방식은 기존과 비슷하게 유지하고 싶었습니다. 


```swift
private func setupUI() {
    recordButton.updateButton(.startRecord)
    submitButton.updateButton(.submit)
    //생략
}
```

```swift
private func setupUI() {
    inviteButton.setConfiguration(
        systemImageName: "link",
        text: String(localized: "초대하기!"),
        backgroundColor: .asYellow
    )

    startButton.setConfiguration(
        systemImageName: "play.fill",
        text: String(localized: "시작하기!"),
        backgroundColor: .asMint
    )
    //생략
}
```

그러기 위해서는 같은 오버로딩을 사용해 같은 기능을하는 코드라는 것을 표현해주는 것이 좋다고 판단했습니다.

Swift의 UIButton문서를 보니 타이틀을 수정하거나 무언갈 수정할 때 setOOO 이런식으로 메소드 이름을 짓는다는 것을 파악할 수 있었습니다.

이에 setConfiguration으로 이름을 변경하고 오버로딩했습니다.

```swift
// 타입을 받는 메서드
func setConfiguration(_ type: ASButtonType? = nil)
// 각각 내용을 받는 메서드
func setConfiguration(
    systemImageName: String? = nil,
    text: String? = nil,
    textStyle: UIFont.TextStyle = .largeTitle,
    backgroundColor: UIColor? = nil,
    cornerStyle: UIButton.Configuration.CornerStyle = .medium,
    baseForegroundColor: UIColor = .asBlack
)
```

결과적으로 외부에서는 setConfiguration 하나의 메서드로 일관되게 관리가 가능해졌습니다!

또한 기존에는 반드시 enum에 case를 추가해야했지만 이제는 추가하거나, 추가하지 않거나 개발자가 선택할 수 있게 되었습니다.

```swift
private func setupUI() {
    recordButton.setConfiguration(.startRecord)
    submitButton.setConfiguration(.submit)
    //생략
}
```

```swift
private func setupUI() {
    inviteButton.setConfiguration(
        systemImageName: "link",
        text: String(localized: "초대하기!"),
        backgroundColor: .asYellow
    )

    startButton.setConfiguration(
        systemImageName: "play.fill",
        text: String(localized: "시작하기!"),
        backgroundColor: .asMint
    )
    //생략
}
```

## 🧐 문제 3: disable

기존에 ASButtonType에 disable도 case로 있었습니다. 하지만 disable은 다른 상태들과는 다른 방식으로 동작한다고 생각했습니다.

왜냐면,, disable은 버튼의 비활성화를 뜻하는 것이지 단순한 버튼의 UI는 아니라고 판단했습니다.

그래서 ASButtonType에서 enum을 통해 disable을 관리하면 혼란이 생긴다고 판단하여 개선해야하는 문제라고 생각했습니다.

```swift
enum ASButtonType {
    case disabled
    case needMorePlayers
    case idle(String, UIColor?)
    case startRecord, recording, reRecord
    case complete
    case submit, submitted
    case startGame
    case startWaiting, endWaiting
    case next
    case nextResultWaiting
}
```

## 💡 개선(해결) 3: 메서드 도입

ASButtonType에서 disable를 삭제했습니다.
(또한 위에서 해결된 문제로 인해 idle도 필요가 없어졌으니 삭제해줬습니다.)

그리고 dsiable처리를 메소드를 통해서 할 수 있도록했습니다.

역시 이부분도 Swift 다른 API와 비슷하게 setEnabled로 이름을 지었습니다.

```swift
/// 버튼의 활성화 여부를 결정하는 메서드입니다.
/// - Parameters:
///    - isEnabled: `true`면 버튼을 활성화하고, `false`면 버튼을 비활성화합니다.
func setEnabled(_ isEnabled: Bool) {
    isEnabled ? enableButton() : disableButton()
}
```

요약하면 아래와 같이 분리가 되었습니다!

- **setConfiguration**
    - 버튼의 UI를 설정
- **setEnabled**
    - 버튼의 활성화 여부를 결정

여기까지하고 확인해보니, `isEnabled = true`는 전부 외부에서 직접 설정해주고 있었고 굳이 명시적으로 색을 다시 바꿔주지 않아도 알아서 바뀌기 때무에 `enableButton()`은 필요가 없다고 생각했습니다!
그래서 아래와 같이 disable만 따로 만들어줬습니다!

```Swift
/// 버튼을 비활성화하면서 스타일을 변경하는 메서드입니다.
func setDisabledState() {
    configurationData = ASButtonConfiguration(
        systemImageName: configurationData?.systemImageName,
        text: configurationData?.text,
        textStyle: configurationData?.textStyle ?? .largeTitle,
        backgroundColor: .systemGray2,
        cornerStyle: configurationData?.cornerStyle ?? .medium,
        baseForegroundColor: configurationData?.baseForegroundColor ?? .asBlack
    )
    isEnabled = false
    applyConfiguration()
}
```

## 👀 욕심1. 조금 더 분리해볼까?

여기까지했는데 조금 더 욕심이 생겼습니다.

기존에는 ASButton이 버튼의 동작도 관리하고 UI도 관리하고 있었습니다.. 이걸 좀 분리해보면 어떨까 고민이 들었습니다.

```swift
// 데이터 bind도 하고,,
func bind(
    to dataSource: Published<Data?>.Publisher
) {
    dataSource
        .receive(on: DispatchQueue.main)
        .sink { [weak self] newHumming in
            if newHumming == nil { return }
            self?.isEnabled = true
            self?.configuration?.baseBackgroundColor = .asGreen
        }
        .store(in: &cancellables)
}

// 상태도 관리하고,,
private func disable(_ color: UIColor = .systemGray2) {
    configuration?.baseBackgroundColor = color
    isEnabled = false
}

// UI 구성도 만드는,,
func setConfiguration(
    systemImageName: String? = nil,
    text: String? = nil,
    textStyle: UIFont.TextStyle = .largeTitle,
    backgroundColor: UIColor? = nil,
    cornerStyle: UIButton.Configuration.CornerStyle = .medium
) {
    var config = UIButton.Configuration.gray()
    config.baseForegroundColor = .asBlack
    config.background.strokeColor = .black
    config.background.strokeWidth = 3
    
    if let systemImageName {
        config.imagePlacement = .leading
        config.image = UIImage(systemName: systemImageName)
        config.imagePadding = 10
        let imageConfig = UIImage.SymbolConfiguration(pointSize: 20, weight: .heavy)
        config.preferredSymbolConfigurationForImage = imageConfig
    }
    
    if let backgroundColor {
        config.baseBackgroundColor = backgroundColor
    }

    if let text {
        var titleAttr = AttributedString(text)
        titleAttr.font = UIFont.font(forTextStyle: textStyle)
        config.attributedTitle = titleAttr
    }

    config.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 12)
    config.cornerStyle = cornerStyle

    setShadow()
    
    config.background.backgroundColorTransformer = UIConfigurationColorTransformer { color in
        color.withAlphaComponent(1.0)
    }

    configurationUpdateHandler = { [weak self] _ in
        guard let self else { return }
        if isHighlighted {
            transform = CGAffineTransform(translationX: 3, y: 3)
            layer.shadowOffset = .zero
        } else {
            transform = .identity
            layer.shadowOffset = CGSize(width: 4, height: 4)
        }
    }
    configuration = config
}
```

한마디로 요약하면 스타일과 관련된 로직을 좀 다른 곳으로 분리시키고 싶었습니다!

그래서 ASButtonConfiguration을 만들게 되었습니다!
정리하면 아래와 같습니다.

**ASButton**

- 데이터 바인딩
- UI 설정을 `적용` (직접하지 않고 요청해서 만들어진 걸 적용만 하도록)
- 버튼 활성화 여부 관리

**ASButtonConfiguration**

- Configuration를 생성

아직 완벽하게 분리가 된 것 같진 않지만 기존보다는 조금 더 분리된 형태인 것 같습니다!
