### PR TITLE
[refacotr] .receive(on: DispatchQueue.main) 중복 호출 개선

### DIFF
--- a/alsongDalsong/ASRepository/ASRepository/Repositories/AnswersRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/AnswersRepository.swift
@@ -16,7 +16,6 @@ final class AnswersRepository: AnswersRepositoryProtocol {
 
     func getAnswersCount() -> AnyPublisher<Int, Never> {
         mainRepository.answers
-            .receive(on: DispatchQueue.main)
             .compactMap { $0 }
             .map { $0.count }
             .eraseToAnyPublisher()
@@ -28,7 +27,6 @@ final class AnswersRepository: AnswersRepositoryProtocol {
         }
 
         return mainRepository.answers
-            .receive(on: DispatchQueue.main)
             .compactMap(\.self)
             .flatMap { answers in
                 Just(answers.first { $0.player?.id == myId })

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/GameStateRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/GameStateRepository.swift
@@ -12,7 +12,6 @@ final class GameStateRepository: GameStateRepositoryProtocol {
 
     func getGameState() -> AnyPublisher<ASEntity.GameState?, Never> {
         Publishers.CombineLatest4(mainRepository.mode, mainRepository.recordOrder, mainRepository.status, mainRepository.round)
-            .receive(on: DispatchQueue.main)
             .map { mode, recordOrder, status, round in
                 guard let mode, let round, let players = self.mainRepository.players.value else { return nil }
                 return ASEntity.GameState(mode: mode, recordOrder: recordOrder, status: status, round: round, players: players)

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/GameStatusRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/GameStatusRepository.swift
@@ -12,20 +12,17 @@ final class GameStatusRepository: GameStatusRepositoryProtocol {
     
     func getStatus() -> AnyPublisher<Status?, Never> {
         mainRepository.status
-            .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()
     }
     
     func getRecordOrder() -> AnyPublisher<UInt8, Never> {
         mainRepository.recordOrder
-            .receive(on: DispatchQueue.main)
             .compactMap { $0 }
             .eraseToAnyPublisher()
     }
     
     func getDueTime() -> AnyPublisher<Date, Never> {
         mainRepository.dueTime
-            .receive(on: DispatchQueue.main)
             .compactMap { $0 }
             .eraseToAnyPublisher()
     }

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/HummingResultRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/HummingResultRepository.swift
@@ -31,7 +31,6 @@ final class HummingResultRepository: HummingResultRepositoryProtocol {
                     return (answer: answer, records: relatedRecords, submit: relatedSubmit, recordOrder: recordOrder ?? 0)
                 }
             }
-            .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()
     }
 

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/PlayersRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/PlayersRepository.swift
@@ -15,14 +15,12 @@ final class PlayersRepository: PlayersRepositoryProtocol {
 
     func getPlayers() -> AnyPublisher<[Player], Never> {
         mainRepository.players
-            .receive(on: DispatchQueue.main)
             .compactMap { $0 }
             .eraseToAnyPublisher()
     }
     
     func getPlayersCount() -> AnyPublisher<Int, Never> {
         mainRepository.players
-            .receive(on: DispatchQueue.main)
             .compactMap { $0 }
             .map { $0.count }
             .eraseToAnyPublisher()
@@ -30,14 +28,12 @@ final class PlayersRepository: PlayersRepositoryProtocol {
 
     func getHost() -> AnyPublisher<Player, Never> {
         mainRepository.host
-            .receive(on: DispatchQueue.main)
             .compactMap { $0 }
             .eraseToAnyPublisher()
     }
     
     func isHost() -> AnyPublisher<Bool, Never> {
         self.getHost()
-            .receive(on: DispatchQueue.main)
             .map { $0.id == ASFirebaseAuth.myID }
             .eraseToAnyPublisher()
     }

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/RoomInfoRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/RoomInfoRepository.swift
@@ -12,14 +12,12 @@ final class RoomInfoRepository: RoomInfoRepositoryProtocol {
     
     func getRoomNumber() -> AnyPublisher<String, Never> {
         mainRepository.number
-            .receive(on: DispatchQueue.main)
             .compactMap { $0 }
             .eraseToAnyPublisher()
     }
     
     func getMode() -> AnyPublisher<Mode, Never> {
         mainRepository.mode
-            .receive(on: DispatchQueue.main)
             .compactMap { $0 }
             .eraseToAnyPublisher()
     }

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/SubmitsRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/SubmitsRepository.swift
@@ -17,7 +17,6 @@ final class SubmitsRepository: SubmitsRepositoryProtocol {
     
     func getSubmitsCount() -> AnyPublisher<Int, Never> {
         mainRepository.submits
-            .receive(on: DispatchQueue.main)
             .compactMap { $0 }
             .map { $0.count }
             .eraseToAnyPublisher()

--- a/alsongDalsong/alsongDalsong/alsongDalsong.xcodeproj/xcshareddata/xcschemes/alsongDalsong.xcscheme
+++ b/alsongDalsong/alsongDalsong/alsongDalsong.xcodeproj/xcshareddata/xcschemes/alsongDalsong.xcscheme
@@ -34,6 +34,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableThreadSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewModel.swift
@@ -67,6 +67,7 @@ final class HummingViewModel: @unchecked Sendable {
 
     private func bindAnswer() {
         answersRepository.getMyAnswer()
+            .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()
             .sink { [weak self] answer in
                 self?.music = answer?.music
@@ -76,6 +77,7 @@ final class HummingViewModel: @unchecked Sendable {
 
     private func bindGameStatus() {
         gameStatusRepository.getDueTime()
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] newDueTime in
                 self?.dueTime = newDueTime
             }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingViewModel.swift
@@ -64,6 +64,7 @@ final class RehummingViewModel: @unchecked Sendable {
 
     private func bindGameStatus() {
         gameStatusRepository.getDueTime()
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] newDueTime in
                 self?.dueTime = newDueTime
             }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
@@ -76,12 +76,14 @@ final class SubmitAnswerViewModel: ObservableObject, @unchecked Sendable {
 
     private func bindGameStatus() {
         gameStatusRepository.getDueTime()
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] newDueTime in
                 self?.dueTime = newDueTime
             }
             .store(in: &cancellables)
 
         gameStatusRepository.getRecordOrder()
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] newRecordOrder in
                 self?.bindRecord(on: newRecordOrder)
                 self?.bindSubmissionStatus()
@@ -94,6 +96,7 @@ final class SubmitAnswerViewModel: ObservableObject, @unchecked Sendable {
         let submitsPublisher = submitsRepository.getSubmitsCount()
 
         playerPublisher.combineLatest(submitsPublisher)
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] playersCount, submitsCount in
                 let submitStatus = (submits: String(submitsCount), total: String(playersCount))
                 self?.submissionStatus = submitStatus


### PR DESCRIPTION
## 필수 리뷰어
- @Sonny-Kor 

## 관련 이슈

- #35 

## 완료 및 수정 내역

 - [x] 레포지토리 내 receive(on:) 호출 제거
 - [x] 뷰 계층에서만 .receive(on:)을 호출하도록 통일

## 테스트 방법 (선택)

## 리뷰 노트
- 없습니다.

## 스크린샷 (선택)
