### PR TITLE
[feat] 컬러 asset 추가 및 버튼 속성 변경

### DIFF
--- a/alsongDalsong/alsongDalsong/alsongDalsong/Resources/Assets.xcassets/asBackground.colorset/Contents.json
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Resources/Assets.xcassets/asBackground.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.957",
-          "green" : "0.773",
-          "red" : "0.384"
+          "blue" : "0xF6",
+          "green" : "0xFF",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xF3",
-          "green" : "0xBC",
-          "red" : "0x61"
+          "blue" : "0.180",
+          "green" : "0.173",
+          "red" : "0.173"
         }
       },
       "idiom" : "universal"

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Resources/Assets.xcassets/asLightRed.colorset/Contents.json
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Resources/Assets.xcassets/asLightRed.colorset/Contents.json
@@ -5,8 +5,8 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.478",
-          "green" : "0.478",
+          "blue" : "0.416",
+          "green" : "0.416",
           "red" : "1.000"
         }
       },

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Resources/Assets.xcassets/asSystem.colorset/Contents.json
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Resources/Assets.xcassets/asSystem.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.741",
-          "green" : "0.600",
-          "red" : "0.294"
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.741",
-          "green" : "0.600",
-          "red" : "0.294"
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
         }
       },
       "idiom" : "universal"

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Resources/Assets.xcassets/blueButtonShadow.colorset/Contents.json
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Resources/Assets.xcassets/blueButtonShadow.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.957",
-          "green" : "0.773",
-          "red" : "0.384"
+          "blue" : "0.318",
+          "green" : "0.318",
+          "red" : "0.737"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xF3",
-          "green" : "0xBC",
-          "red" : "0x61"
+          "blue" : "0.741",
+          "green" : "0.600",
+          "red" : "0.294"
         }
       },
       "idiom" : "universal"

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Resources/Assets.xcassets/musicPlayerBackground.colorset/Contents.json
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Resources/Assets.xcassets/musicPlayerBackground.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.957",
-          "green" : "0.773",
-          "red" : "0.384"
+          "blue" : "0.851",
+          "green" : "0.851",
+          "red" : "0.851"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xF3",
-          "green" : "0xBC",
-          "red" : "0x61"
+          "blue" : "0.090",
+          "green" : "0.090",
+          "red" : "0.090"
         }
       },
       "idiom" : "universal"

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Resources/Assets.xcassets/purplePanel.colorset/Contents.json
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Resources/Assets.xcassets/purplePanel.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xF6",
-          "green" : "0xF4",
-          "red" : "0xF2"
+          "blue" : "0.996",
+          "green" : "0.580",
+          "red" : "0.678"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.255",
-          "green" : "0.220",
-          "red" : "0.188"
+          "blue" : "0.996",
+          "green" : "0.639",
+          "red" : "0.690"
         }
       },
       "idiom" : "universal"

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Resources/Assets.xcassets/recordPanel.colorset/Contents.json
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Resources/Assets.xcassets/recordPanel.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.231",
-          "green" : "0.161",
-          "red" : "0.118"
+          "blue" : "0.090",
+          "green" : "0.090",
+          "red" : "0.090"
         }
       },
       "idiom" : "universal"

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Resources/Assets.xcassets/redButtonShadow.colorset/Contents.json
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Resources/Assets.xcassets/redButtonShadow.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.957",
-          "green" : "0.773",
-          "red" : "0.384"
+          "blue" : "0.318",
+          "green" : "0.318",
+          "red" : "0.737"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xF3",
-          "green" : "0xBC",
-          "red" : "0x61"
+          "blue" : "0.318",
+          "green" : "0.318",
+          "red" : "0.737"
         }
       },
       "idiom" : "universal"

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
@@ -31,7 +31,7 @@ final class ASButton: UIButton {
         textStyle: UIFont.TextStyle = .largeTitle,
         backgroundColor: UIColor? = nil,
         cornerStyle: UIButton.Configuration.CornerStyle = .medium,
-        baseForegroundColor: UIColor = .asBlack
+        baseForegroundColor: UIColor = .white
     ) {
         configurationData = ASButtonConfiguration(
             systemImageName: systemImageName,
@@ -44,7 +44,7 @@ final class ASButton: UIButton {
 
         applyConfiguration()
     }
-    
+
     /// 버튼의 UI 관련한 Configuration을 설정하는 메서드
     func setConfiguration(
         _ type: ASButtonType? = nil
@@ -59,7 +59,7 @@ final class ASButton: UIButton {
 
         applyConfiguration()
     }
-    
+
     func bind(
         to dataSource: Published<Data?>.Publisher,
         baseBackgroundColor: UIColor = .asGreen
@@ -67,13 +67,13 @@ final class ASButton: UIButton {
         dataSource
             .receive(on: DispatchQueue.main)
             .compactMap { $0 }
-            .sink { [weak self] data in
+            .sink { [weak self] _ in
                 self?.configuration?.baseBackgroundColor = baseBackgroundColor
                 self?.isEnabled = true
             }
             .store(in: &cancellables)
     }
-    
+
     /// 버튼을 비활성화하면서 스타일을 변경하는 메서드입니다.
     func setDisabledState() {
         configurationData = ASButtonConfiguration(
@@ -82,7 +82,7 @@ final class ASButton: UIButton {
             textStyle: configurationData?.textStyle ?? .largeTitle,
             backgroundColor: .systemGray2,
             cornerStyle: configurationData?.cornerStyle ?? .medium,
-            baseForegroundColor: configurationData?.baseForegroundColor ?? .asBlack
+            baseForegroundColor: configurationData?.baseForegroundColor ?? .white
         )
         isEnabled = false
         applyConfiguration()
@@ -97,7 +97,7 @@ final class ASButton: UIButton {
         case startWaiting, endWaiting
         case next
         case nextResultWaiting
-        
+
         var text: String {
             switch self {
                 case .needMorePlayers: String(localized: "게임 인원 부족")
@@ -136,7 +136,7 @@ final class ASButton: UIButton {
                 default: nil
             }
         }
-        
+
         var textStyle: UIFont.TextStyle {
             .largeTitle
         }
@@ -150,7 +150,7 @@ final class ASButton: UIButton {
 private extension ASButton {
     /// Configuration을 적용하는 메서드
     func applyConfiguration() {
-        self.configuration = configurationData?.createConfiguration()
+        configuration = configurationData?.createConfiguration()
     }
 
     /// 버튼이 눌렸을 때 효과를 적용하는 메서드
@@ -160,10 +160,10 @@ private extension ASButton {
             layer.shadowOffset = .zero
         } else {
             transform = .identity
-            layer.shadowOffset = CGSize(width: 4, height: 4)
+            layer.shadowOffset = CGSize(width: 0, height: 8)
         }
     }
-    
+
     /// 버튼 초기설정을 담당하는 메서드
     func setupButton() {
         setShadow()

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
@@ -31,7 +31,8 @@ final class ASButton: UIButton {
         textStyle: UIFont.TextStyle = .largeTitle,
         backgroundColor: UIColor? = nil,
         cornerStyle: UIButton.Configuration.CornerStyle = .medium,
-        baseForegroundColor: UIColor = .white
+        baseForegroundColor: UIColor = .white,
+        shadowColor: UIColor = .asShadow
     ) {
         configurationData = ASButtonConfiguration(
             systemImageName: systemImageName,
@@ -41,7 +42,7 @@ final class ASButton: UIButton {
             cornerStyle: cornerStyle,
             baseForegroundColor: baseForegroundColor
         )
-
+        setShadow(color: shadowColor, width: 0, height: 8)
         applyConfiguration()
     }
 
@@ -56,7 +57,6 @@ final class ASButton: UIButton {
             backgroundColor: type?.backgroundColor,
             cornerStyle: type?.cornerStyle ?? .medium
         )
-
         applyConfiguration()
     }
 
@@ -144,6 +144,10 @@ final class ASButton: UIButton {
         var cornerStyle: UIButton.Configuration.CornerStyle {
             .medium
         }
+
+        var shadowColor: UIColor? {
+            .asShadow
+        }
     }
 }
 
@@ -156,7 +160,7 @@ private extension ASButton {
     /// 버튼이 눌렸을 때 효과를 적용하는 메서드
     func applyHighlightEffect() {
         if isHighlighted {
-            transform = CGAffineTransform(translationX: 3, y: 3)
+            transform = CGAffineTransform(translationX: 0, y: 8)
             layer.shadowOffset = .zero
         } else {
             transform = .identity

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButtonConfiguration.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButtonConfiguration.swift
@@ -9,7 +9,6 @@ extension ASButton {
         let backgroundColor: UIColor?
         let cornerStyle: UIButton.Configuration.CornerStyle
         let baseForegroundColor: UIColor
-        
         init(
             systemImageName: String? = nil,
             text: String? = nil,

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButtonConfiguration.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButtonConfiguration.swift
@@ -16,7 +16,7 @@ extension ASButton {
             textStyle: UIFont.TextStyle = .largeTitle,
             backgroundColor: UIColor? = nil,
             cornerStyle: UIButton.Configuration.CornerStyle = .medium,
-            baseForegroundColor: UIColor = .asBlack
+            baseForegroundColor: UIColor = .white
         ) {
             self.systemImageName = systemImageName
             self.text = text
@@ -30,8 +30,6 @@ extension ASButton {
         func createConfiguration() -> UIButton.Configuration {
             var config = UIButton.Configuration.gray()
             config.baseForegroundColor = baseForegroundColor
-            config.background.strokeColor = .black
-            config.background.strokeWidth = 3
             
             if let systemImageName {
                 config.imagePlacement = .leading

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/Alert/ASAlertController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/Alert/ASAlertController.swift
@@ -38,7 +38,7 @@ class ASAlertController: UIViewController {
 
     private func setAlertView() {
         alertView.transform = CGAffineTransform(scaleX: 1.2, y: 1.2)
-        alertView.backgroundColor = .asLightGray
+        alertView.backgroundColor = .asBackground
         alertView.layer.borderWidth = 2.5
         alertView.layer.borderColor = UIColor.asBlack.cgColor
         view.addSubview(alertView)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Guide/GuideViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Guide/GuideViewController.swift
@@ -30,7 +30,7 @@ final class GuideViewController: UIViewController {
     
     private func setupUI() {
         self.navigationController?.navigationBar.isHidden = true
-        view.backgroundColor = .asLightGray
+        view.backgroundColor = .asBackground
         titleLabel.text = type.title.localized()
         descriptionLabel.text = type.description.localized()
         cautionLabel.isHidden = true

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewController.swift
@@ -50,7 +50,7 @@ final class HummingViewController: UIViewController {
         buttonStack.addArrangedSubview(submitButton)
         scrollView.addSubview(musicPanel)
         scrollView.addSubview(hummingPanel)
-        view.backgroundColor = .asLightGray
+        view.backgroundColor = .asBackground
         view.addSubview(progressBar)
         view.addSubview(scrollView)
         view.addSubview(buttonStack)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewController.swift
@@ -31,7 +31,7 @@ final class LoadingViewController: UIViewController {
     }
     
     private func setupUI() {
-        view.backgroundColor = .asLightGray
+        view.backgroundColor = .asBackground
         loadingStatusLabel.font = .font(forTextStyle: .body)
         [logoImageView, activityIndicatorView, loadingStatusLabel].forEach {
             view.addSubview($0)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyView.swift
@@ -68,7 +68,7 @@ struct LobbyView: View {
                 }
             }
         }
-        .background(Color.asLightGray)
+        .background(Color.asBackground)
     }
 
     func presentKickAlert(player: Player) {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
@@ -60,7 +60,7 @@ final class LobbyViewController: UIViewController {
     }
 
     private func setupUI() {
-        view.backgroundColor = .asLightGray
+        view.backgroundColor = .asBackground
 
         inviteButton.setConfiguration(
             systemImageName: "link",

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewController.swift
@@ -104,7 +104,7 @@ final class OnboardingViewController: UIViewController {
                     self?.showMicrophonePermissionAlert()
                     return
                 }
-                
+
                 self?.showCreateRoomLoading()
             },
             for: .touchUpInside
@@ -116,7 +116,7 @@ final class OnboardingViewController: UIViewController {
                     self?.showMicrophonePermissionAlert()
                     return
                 }
-                
+
                 guard let inviteCode = self?.inviteCode else { return }
                 inviteCode.isEmpty ?
                     self?.showRoomNumerInputAlert() : self?.autoJoinRoom()
@@ -135,12 +135,14 @@ final class OnboardingViewController: UIViewController {
         createRoomButton.setConfiguration(
             systemImageName: "",
             text: Constants.craeteButtonTitle,
-            backgroundColor: .asLightRed
+            backgroundColor: .asLightRed,
+            shadowColor: .redButtonShadow
         )
         joinRoomButton.setConfiguration(
             systemImageName: "",
             text: Constants.joinButtonTitle,
-            backgroundColor: .asLightSky
+            backgroundColor: .asLightSky,
+            shadowColor: .blueButtonShadow
         )
     }
 
@@ -224,10 +226,10 @@ final class OnboardingViewController: UIViewController {
             throw error
         }
     }
-    
+
     private func isMicrophoneAuthorized() -> Bool {
         let status = AVCaptureDevice.authorizationStatus(for: .audio)
-        
+
         return status == .authorized
     }
 }
@@ -267,13 +269,13 @@ extension OnboardingViewController {
         let alert = DefaultAlertController(titleText: .permissionDenied, primaryButtonText: .setting, secondaryButtonText: .cancel) { _ in
             guard let settingsURL = URL(string: UIApplication.openSettingsURLString),
                   UIApplication.shared.canOpenURL(settingsURL) else { return }
-            
+
             UIApplication.shared.open(settingsURL, options: [:], completionHandler: nil)
         }
-        
+
         presentAlert(alert)
     }
-    
+
     private func showCreateRoomLoading() {
         let alert = LoadingAlertController(
             progressText: .joinRoom,

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewController.swift
@@ -52,7 +52,7 @@ final class OnboardingViewController: UIViewController {
     }
 
     private func setupUI() {
-        view.backgroundColor = .asLightGray
+        view.backgroundColor = .asBackground
         for item in [createRoomButton, joinRoomButton, logoImageView, avatarView, nickNamePanel, avatarRefreshButton] {
             view.addSubview(item)
             item.translatesAutoresizingMaskIntoConstraints = false
@@ -135,12 +135,12 @@ final class OnboardingViewController: UIViewController {
         createRoomButton.setConfiguration(
             systemImageName: "",
             text: Constants.craeteButtonTitle,
-            backgroundColor: .asYellow
+            backgroundColor: .asLightRed
         )
         joinRoomButton.setConfiguration(
             systemImageName: "",
             text: Constants.joinButtonTitle,
-            backgroundColor: .asMint
+            backgroundColor: .asLightSky
         )
     }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingViewController.swift
@@ -54,7 +54,7 @@ final class RehummingViewController: UIViewController {
         buttonStack.addArrangedSubview(submitButton)
         scrollView.addSubview(musicPanel)
         scrollView.addSubview(hummingPanel)
-        view.backgroundColor = .asLightGray
+        view.backgroundColor = .asBackground
         view.addSubview(progressBar)
         view.addSubview(scrollView)
         view.addSubview(buttonStack)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewController.swift
@@ -26,7 +26,7 @@ class HummingResultViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .asLightGray
+        view.backgroundColor = .asBackground
         setupUI()
         setupLayout()
         bindViewModel()
@@ -52,7 +52,7 @@ class HummingResultViewController: UIViewController {
         resultTableViewDiffableDataSource = HummingResultTableViewDiffableDataSource(tableView: resultTableView)
         resultTableView.separatorStyle = .none
         resultTableView.allowsSelection = false
-        resultTableView.backgroundColor = .asLightGray
+        resultTableView.backgroundColor = .asBackground
         resultTableView.contentInset = UIEdgeInsets(top: 10, left: 0, bottom: 0, right: 0)
     }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicView.swift
@@ -65,7 +65,7 @@ struct SelectMusicView: View {
                 }
             }
         }
-        .background(.asLightGray)
+        .background(.asBackground)
     }
 }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewController.swift
@@ -36,7 +36,7 @@ final class SelectMusicViewController: UIViewController {
     }
     
     private func setupUI() {
-        view.backgroundColor = .asLightGray
+        view.backgroundColor = .asBackground
         submitButton.setConfiguration(text: String(localized: "선택 완료"), backgroundColor: .asGreen)
         submitButton.setDisabledState()
         let musicView = SelectMusicView(viewModel: viewModel)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SelectAnswerView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SelectAnswerView.swift
@@ -61,7 +61,7 @@ struct SelectAnswerView: View {
                     .scrollDismissesKeyboard(.immediately)
                 }
             }
-            .background(.asLightGray)
+            .background(.asBackground)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("완료") {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewController.swift
@@ -45,13 +45,13 @@ final class SubmitAnswerViewController: UIViewController {
 
     private func setupUI() {
         selectAnswerButton.setConfiguration(text: String(localized: "정답 선택"), backgroundColor: .asLightSky)
-        submitButton.setConfiguration(text: String(localized: "정답 제출"), backgroundColor: .asLightGray)
+        submitButton.setConfiguration(text: String(localized: "정답 제출"), backgroundColor: .asBackground)
         submitButton.setDisabledState()
         buttonStack.axis = .horizontal
         buttonStack.spacing = 16
         buttonStack.addArrangedSubview(selectAnswerButton)
         buttonStack.addArrangedSubview(submitButton)
-        view.backgroundColor = .asLightGray
+        view.backgroundColor = .asBackground
     }
 
     private func setupLayout() {


### PR DESCRIPTION
## 필수 리뷰어

## 관련 이슈
- #42 

## 완료 및 수정 내역
 - [x] 버튼 디자인(그림자는 미적용)

## 테스트 방법 (선택)

## 리뷰 노트

레이아웃이랑 싹다 하려다가 그림자 부분의 정책을 결정하는 것을 좀 논의 한 뒤에 하는게 좋을 것 같아서 이 브랜치에서 따로 뽑아 내서 레이아웃이랑 다른 디자인 적용하겠습니다..

그림자 문제는 다음과 같습니다. 저희 버튼의 두께는 그림자를 이용해서 만드는데요, 버튼의 그림자는 현재 ASButton쪽에서 관리하는 것이 아닌 UIView Extension에서 관리중입니다. 그에 따라 버튼 두께 부분에 색을 적용해야하는데 이것을 Configuaration에서 같이 관리를 해줄 수가 없는 것 같습니다. 그래서 setConfiguration을 하는 부분에서 따로 파라미터를 받아 ASButton 내부에 그림자 색을 지정하는 메소드를 따로 만드는것이 좋을지? 의논해본 뒤에 적용하고싶습니다. 

그리고 컴퍼넌트별로 사용될 색으로 이름 변경해 뒀고, 색상 이름을 색상이름(blue, lightblue)방식으로 할지 사용하는 컴포넌트의 이름으로 할지 고민하다가 아직 전체 적용한 것은 아니고 새로 등장할 색들에 대해서는 컴포넌트의 이름으로 색상 이름을 정하도록 해놓았습니다. 이부분도 의견주시면 감사하겠습니다.

## 스크린샷 (선택)
![Simulator Screenshot - iPhone 16 Pro - 2025-03-27 at 23 53 00](https://github.com/user-attachments/assets/faff9dc6-80e0-420b-ae24-66fc1d5915be)

