### PR TITLE
[feat] 노래 검색 Pagination & Infinite Scrolling

### DIFF
--- a/alsongDalsong/ASMusicKit/ASMusicKit/ASMusicAPI.swift
+++ b/alsongDalsong/ASMusicKit/ASMusicKit/ASMusicAPI.swift
@@ -22,7 +22,7 @@ public struct ASMusicAPI {
 
                     let result = try await request.response()
 
-                    if !result.topResults.isEmpty {
+                    if !result.topResults.isEmpty, offset == 0 {
                         let music = result.topResults.compactMap { topResult -> ASEntity.Music? in
                             if case .song(let song) = topResult {
                                 return ASEntity.Music(

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/ASSearchBar.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/ASSearchBar.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct ASSearchBar: View {
     @Binding var text: String
     let placeHolder: String
-    
+
     var body: some View {
         HStack {
             HStack {
@@ -11,7 +11,7 @@ struct ASSearchBar: View {
  
                 TextField(placeHolder, text: $text)
                     .foregroundColor(.primary)
- 
+
                 if !text.isEmpty {
                     Button(action: {
                         self.text = ""

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicView.swift
@@ -73,7 +73,3 @@ struct SelectMusicView: View {
         .background(.asBackground)
     }
 }
-
-//#Preview {
-//    SelectMusicView(v)
-//}

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicView.swift
@@ -59,6 +59,11 @@ struct SelectMusicView: View {
                             })
                             .tint(.black)
                         }
+                        .onAppear {
+                            Task {
+                                await viewModel.fetchNextSearchList(currentMusic: music)
+                            }
+                        }
                     }
                     .listStyle(.plain)
                     .scrollDismissesKeyboard(.immediately)
@@ -69,6 +74,6 @@ struct SelectMusicView: View {
     }
 }
 
-#Preview {
+//#Preview {
 //    SelectMusicView(v)
-}
+//}

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
@@ -29,7 +29,12 @@ final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
 
     private let musicAPI = ASMusicAPI()
     private var cancellables = Set<AnyCancellable>()
-    
+
+    private let pageSize: Int = 10
+    private var currentPage: Int = 0
+    private var isLoadingPage: Bool = false
+    private var isAllLoaded: Bool = false
+
     init(
         playersRepository: PlayersRepositoryProtocol,
         answerRepository: AnswersRepositoryProtocol,
@@ -75,11 +80,12 @@ final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
         $searchTerm
             .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
             .sink { [weak self] term in
-                guard let self, !term.isEmpty else {
-                    self?.resetSearchList()
-                    return
-                }
                 Task { [weak self] in
+                    if term.isEmpty {
+                        await self?.resetSearchList()
+                        return
+                    }
+                    await self?.resetSearchList()
                     try? await self?.searchMusic(text: term)
                 }
             }
@@ -123,8 +129,12 @@ final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
     func searchMusic(text: String) async throws {
         do {
             if text.isEmpty { return }
+
+            currentPage = 1
+            isAllLoaded = false
+
             await updateIsSearching(with: true)
-            let searchList = try await musicAPI.search(for: text)
+            let searchList = try await musicAPI.search(for: text, pageSize, 0)
             await updateSearchList(with: searchList)
             await updateIsSearching(with: false)
         } catch {
@@ -173,7 +183,8 @@ final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
         guard let url = selectedMusic?.previewUrl else { return }
         downloadMusic(url: url)
     }
-    
+
+    @MainActor
     func resetSearchList() {
         searchList = []
     }
@@ -195,5 +206,40 @@ final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
     
     func cancelSubscriptions() {
         cancellables.removeAll()
+    }
+
+    /// MusicKit을 통해 다음 페이지의 Apple Music 노래를 검색합니다.
+    /// - Parameters:
+    ///   - currentMusic: 현재 SelectMusicView.swift에서 로딩되고 있는 Music Data
+    func fetchNextSearchList(currentMusic: Music? = nil) async {
+        guard !isLoadingPage, !isAllLoaded else { return }
+
+        if let currentMusic = currentMusic {
+            guard let index = searchList.firstIndex(where: { $0.id == currentMusic.id }),
+                  index >= searchList.count - 3 else { return }
+        }
+
+        isLoadingPage = true
+
+        defer {
+            isLoadingPage = false
+        }
+
+        do {
+            let nextSearchList = try await musicAPI.search(for: searchTerm, pageSize, currentPage * pageSize)
+            print(currentPage)
+            if nextSearchList.isEmpty {
+                isAllLoaded = true
+            } else {
+                currentPage += 1
+                await MainActor.run {
+                    let existingIDs = Set(searchList.map { $0.id })
+                    let filteredNextSearchList = nextSearchList.filter { !existingIDs.contains($0.id) }
+                    searchList.append(contentsOf: filteredNextSearchList)
+                }
+            }
+        } catch {
+            ErrorHandler.handle(error)
+        }
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
@@ -129,14 +129,11 @@ final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
     func searchMusic(text: String) async throws {
         do {
             if text.isEmpty { return }
-
-            currentPage = 1
-            isAllLoaded = false
-
             await updateIsSearching(with: true)
             let searchList = try await musicAPI.search(for: text, pageSize, 0)
             await updateSearchList(with: searchList)
             await updateIsSearching(with: false)
+            currentPage += 1
         } catch {
             ErrorHandler.handle(error)
             throw ASError.searchMusicOnSelect
@@ -187,6 +184,8 @@ final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
     @MainActor
     func resetSearchList() {
         searchList = []
+        currentPage = 0
+        isAllLoaded = false
     }
     
     @MainActor
@@ -216,7 +215,7 @@ final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
 
         if let currentMusic = currentMusic {
             guard let index = searchList.firstIndex(where: { $0.id == currentMusic.id }),
-                  index >= searchList.count - 3 else { return }
+                  index >= searchList.count - 1 else { return }
         }
 
         isLoadingPage = true
@@ -226,8 +225,9 @@ final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
         }
 
         do {
+            Logger.debug(currentPage)
             let nextSearchList = try await musicAPI.search(for: searchTerm, pageSize, currentPage * pageSize)
-            print(currentPage)
+
             if nextSearchList.isEmpty {
                 isAllLoaded = true
             } else {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SelectAnswerView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SelectAnswerView.swift
@@ -38,6 +38,7 @@ struct SelectAnswerView: View {
 
                 ASSearchBar(text: $viewModel.searchTerm, placeHolder: String(localized: "노래를 선택하세요"))
                     .focused($isFocused)
+                
                 if viewModel.isSearching {
                     VStack {
                         Spacer()
@@ -45,6 +46,7 @@ struct SelectAnswerView: View {
                             .scaleEffect(2.0)
                         Spacer()
                     }
+                    .scrollDismissesKeyboard(.immediately)
                 } else {
                     List(viewModel.searchList) { music in
                         Button {
@@ -54,6 +56,11 @@ struct SelectAnswerView: View {
                                 await viewModel.downloadArtwork(url: url)
                             })
                             .tint(.black)
+                        }
+                        .onAppear {
+                            Task {
+                                await viewModel.fetchNextSearchList(currentMusic: music)
+                            }
                         }
                     }
                     .listStyle(.plain)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SelectAnswerView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SelectAnswerView.swift
@@ -38,7 +38,7 @@ struct SelectAnswerView: View {
 
                 ASSearchBar(text: $viewModel.searchTerm, placeHolder: String(localized: "노래를 선택하세요"))
                     .focused($isFocused)
-                
+
                 if viewModel.isSearching {
                     VStack {
                         Spacer()

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
@@ -31,6 +31,11 @@ final class SubmitAnswerViewModel: ObservableObject, @unchecked Sendable {
     private let musicAPI = ASMusicAPI()
     private var cancellables: Set<AnyCancellable> = []
 
+    private let pageSize: Int = 10
+    private var currentPage: Int = 0
+    private var isLoadingPage: Bool = false
+    private var isAllLoaded: Bool = false
+
     init(
         gameStatusRepository: GameStatusRepositoryProtocol,
         playersRepository: PlayersRepositoryProtocol,
@@ -55,11 +60,12 @@ final class SubmitAnswerViewModel: ObservableObject, @unchecked Sendable {
         $searchTerm
             .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
             .sink { [weak self] term in
-                guard let self, !term.isEmpty else {
-                    self?.resetSearchList()
-                    return
-                }
                 Task { [weak self] in
+                    if term.isEmpty {
+                        await self?.resetSearchList()
+                        return
+                    }
+                    await self?.resetSearchList()
                     try? await self?.searchMusic(text: term)
                 }
             }
@@ -159,9 +165,10 @@ final class SubmitAnswerViewModel: ObservableObject, @unchecked Sendable {
         do {
             if text.isEmpty { return }
             await updateIsSearching(with: true)
-            let searchList = try await musicAPI.search(for: text)
+            let searchList = try await musicAPI.search(for: text, pageSize, 0)
             await updateSearchList(with: searchList)
             await updateIsSearching(with: false)
+            currentPage += 1
         } catch {
             ErrorHandler.handle(error)
             throw ASError.searchMusicOnSubmit
@@ -190,6 +197,7 @@ final class SubmitAnswerViewModel: ObservableObject, @unchecked Sendable {
 
     // MARK: - 이부분 부터 RehummingViewModel
 
+    @MainActor
     func resetSearchList() {
         searchList = []
     }
@@ -211,5 +219,41 @@ final class SubmitAnswerViewModel: ObservableObject, @unchecked Sendable {
 
     func cancelSubscriptions() {
         cancellables.removeAll()
+    }
+
+    /// MusicKit을 통해 다음 페이지의 Apple Music 노래를 검색합니다.
+    /// - Parameters:
+    ///   - currentMusic: 현재 SelectMusicView.swift에서 로딩되고 있는 Music Data
+    func fetchNextSearchList(currentMusic: Music? = nil) async {
+        guard !isLoadingPage, !isAllLoaded else { return }
+
+        if let currentMusic = currentMusic {
+            guard let index = searchList.firstIndex(where: { $0.id == currentMusic.id }),
+                  index >= searchList.count - 1 else { return }
+        }
+
+        isLoadingPage = true
+
+        defer {
+            isLoadingPage = false
+        }
+
+        do {
+            Logger.debug(currentPage)
+            let nextSearchList = try await musicAPI.search(for: searchTerm, pageSize, currentPage * pageSize)
+
+            if nextSearchList.isEmpty {
+                isAllLoaded = true
+            } else {
+                currentPage += 1
+                await MainActor.run {
+                    let existingIDs = Set(searchList.map { $0.id })
+                    let filteredNextSearchList = nextSearchList.filter { !existingIDs.contains($0.id) }
+                    searchList.append(contentsOf: filteredNextSearchList)
+                }
+            }
+        } catch {
+            ErrorHandler.handle(error)
+        }
     }
 }


### PR DESCRIPTION
## 필수 리뷰어

- none

## 관련 이슈

- #52 

## 완료 및 수정 내역

 - [x] (노래 선택, 정답 선택 화면) 노래 검색 시 Pagination을 적용
 - [x] Sheet 관련 에러 수정 <- 문제가 없는걸로 확인

## 리뷰 노트
### 데이터 로딩 기준
기존에는 검색어 연관 추천 리스트 Top 10의 노래 데이터만 가져왔습니다.

추천을 계속 받으면 참 좋겠지만 아쉽게도 MusicAPI에서 제공하는 추천 메서드(`MusicCatalogSearchSuggestionsRequest`)는 Top 10 즉, 10개의 데이터만을 주로 리턴합니다.

따라서 기존 기준을 계속 사용하되, 무한 스크롤을 구현하기 위해 currentPage == 0 일 때(offset == 0)는 추천 Top 10을 가져오고,

이후 스크롤을 통해 다음 데이터를 받아올 때에는 검색어 연관 리스트를 받아오게 했습니다.

### ⚠️ [Help] SwiftUI에서 키보드 올라옴/내려옴에 따른 재렌더링 문제
현재 SwiftUI 관련 문제가 발생했으나, 해결하지 못하고 있습니다.

1. 사용자가 검색어를 입력하면 정상적으로 Music 데이터가 출력되는데, 키보드를 내릴 시 다시 List를 로딩합니다.
2. 이후 사용자가 스크롤을 하다가 다시 검색어를 수정하고자 하면 키보드가 올라오고 이때 다시 List가 로딩되며 첫번째 cell로 위치가 이동됩니다.

이를 해결하고자 

- 조건문 밖으로 List를 빼거나
- List를 변수로 만들어서 동일한 List를 사용하게 하거나
- id 값을 주는 등

reRendering을 막고자 시도했지만, 여전히 동일한 문제가 해결되고 있지 않습니다. 
아까 스터디때 잠시 나왔던 StateObject는 View와 ViewController에서 동일한 Model을 사용해야하기 때문에 시도하지 않았습니다.

## 스크린샷 (선택)
