### PR TITLE
[feat] 런치스크린 애니메이션

### DIFF
--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewController.swift
@@ -37,9 +37,11 @@ final class LoadingViewController: UIViewController {
         
         titleLabel.text = "알쏭달쏭"
         titleLabel.font = .font(.riaSans, ofSize: 80)
+        titleLabel.textColor = .onboardingForeground
         
         subtitleLabel.text = "기다려라"
         subtitleLabel.font = .font(.riaSans, ofSize: 20)
+        subtitleLabel.textColor = .onboardingForeground
                 
         activityIndicatorView.startAnimating()
         
@@ -70,7 +72,9 @@ final class LoadingViewController: UIViewController {
                   let avatars = self?.viewModel?.avatars,
                   let selectedAvatar = self?.viewModel?.selectedAvatar else { return }
             
-            self?.navigateToOnboarding(avatars: avatars, selectedAvatar: selectedAvatar, avatarData: avatarData)
+            self?.titleLabelAnimation { _ in
+                self?.navigateToOnboarding(avatars: avatars, selectedAvatar: selectedAvatar, avatarData: avatarData)
+            }
         }
     }
     
@@ -82,6 +86,30 @@ final class LoadingViewController: UIViewController {
             .receive(on: DispatchQueue.main)
             .sink(receiveValue: handler)
             .store(in: &cancellables)
+    }
+    
+    private func titleLabelAnimation(completion: @escaping (UIViewAnimatingPosition) -> Void) {
+        guard let superview = titleLabel.superview else { return }
+
+        let currentY = superview.convert(titleLabel.frame, to: nil).minY
+        let targetY = view.safeAreaInsets.top
+                
+        let scaleFactor: CGFloat = 32 / 80 // 폰트 크기 변화
+        let fontHeightDifference = titleLabel.frame.height * (1 - scaleFactor) // 변한 폰트의 크기
+        
+        // 이동할 거리 계산
+        let translationY = targetY - currentY - (fontHeightDifference / 2)
+
+        let animator = UIViewPropertyAnimator(duration: 1, dampingRatio: 0.85) { [weak self] in
+            self?.titleLabel.transform = CGAffineTransform(translationX: 0, y: translationY)
+                .scaledBy(x: scaleFactor, y: scaleFactor)
+            
+            self?.subtitleLabel.alpha = 0
+            self?.activityIndicatorView.alpha = 0
+        }
+
+        animator.addCompletion(completion)
+        animator.startAnimation()
     }
     
     private func navigateToOnboarding(avatars: [URL], selectedAvatar: URL, avatarData: Data) {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewController.swift
@@ -5,9 +5,11 @@ import Combine
 import UIKit
 
 final class LoadingViewController: UIViewController {
-    private let logoImageView = UIImageView(image: UIImage(named: "logo"))
-    private let activityIndicatorView = UIActivityIndicatorView(style: .large)
-    private let loadingStatusLabel = UILabel()
+    private let titleLabel = UILabel()
+    private let subtitleLabel = UILabel()
+    private let activityIndicatorView = UIActivityIndicatorView(style: .medium)
+    private let stackView = UIStackView()
+    
     private var viewModel: LoadingViewModel?
     private var inviteCode = ""
     private var cancellables = Set<AnyCancellable>()
@@ -32,25 +34,33 @@ final class LoadingViewController: UIViewController {
     
     private func setupUI() {
         view.backgroundColor = .asBackground
-        loadingStatusLabel.font = .font(forTextStyle: .body)
-        [logoImageView, activityIndicatorView, loadingStatusLabel].forEach {
-            view.addSubview($0)
-            $0.translatesAutoresizingMaskIntoConstraints = false
-        }
+        
+        titleLabel.text = "알쏭달쏭"
+        titleLabel.font = .font(.riaSans, ofSize: 80)
+        
+        subtitleLabel.text = "기다려라"
+        subtitleLabel.font = .font(.riaSans, ofSize: 20)
+                
+        activityIndicatorView.startAnimating()
+        
+        stackView.axis = .vertical
+        stackView.alignment = .center
+        stackView.spacing = 8
+        
+        stackView.addArrangedSubview(titleLabel)
+        stackView.addArrangedSubview(subtitleLabel)
+        stackView.addArrangedSubview(activityIndicatorView)
+        
+        view.addSubview(stackView)
     }
     
     private func setupLayout() {
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        
         NSLayoutConstraint.activate([
-            logoImageView.widthAnchor.constraint(equalToConstant: 356),
-            logoImageView.heightAnchor.constraint(equalToConstant: 160),
-            logoImageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            logoImageView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 48),
-            
-            activityIndicatorView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            activityIndicatorView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            
-            loadingStatusLabel.topAnchor.constraint(equalTo: activityIndicatorView.bottomAnchor, constant: 16),
-            loadingStatusLabel.centerXAnchor.constraint(equalTo: activityIndicatorView.centerXAnchor)
+            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            stackView.centerYAnchor.constraint(equalTo: view.centerYAnchor)
         ])
     }
     
@@ -61,11 +71,6 @@ final class LoadingViewController: UIViewController {
                   let selectedAvatar = self?.viewModel?.selectedAvatar else { return }
             
             self?.navigateToOnboarding(avatars: avatars, selectedAvatar: selectedAvatar, avatarData: avatarData)
-        }
-        
-        bind(viewModel?.$loadingStatus) { [weak self] status in
-            self?.loadingStatusLabel.text = status
-            self?.activityIndicatorView.startAnimating()
         }
     }
     
@@ -103,6 +108,7 @@ final class LoadingViewController: UIViewController {
         {
             window.rootViewController = navigationController
             window.makeKeyAndVisible()
+            UIView.transition(with: window, duration: 1, options: .transitionCrossDissolve, animations: nil, completion: nil)
         }
     }
     

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewController.swift
@@ -94,10 +94,9 @@ final class LoadingViewController: UIViewController {
         let currentY = superview.convert(titleLabel.frame, to: nil).minY
         let targetY = view.safeAreaInsets.top
                 
-        let scaleFactor: CGFloat = 32 / 80 // 폰트 크기 변화
-        let fontHeightDifference = titleLabel.frame.height * (1 - scaleFactor) // 변한 폰트의 크기
+        let scaleFactor: CGFloat = 32 / 80 /// 폰트 크기 변화
+        let fontHeightDifference = titleLabel.frame.height * (1 - scaleFactor)
         
-        // 이동할 거리 계산
         let translationY = targetY - currentY - (fontHeightDifference / 2)
 
         let animator = UIViewPropertyAnimator(duration: 1, dampingRatio: 0.85) { [weak self] in

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewController.swift
@@ -72,7 +72,7 @@ final class LoadingViewController: UIViewController {
                   let avatars = self?.viewModel?.avatars,
                   let selectedAvatar = self?.viewModel?.selectedAvatar else { return }
             
-            self?.titleLabelAnimation { _ in
+            self?.titleLabelAnimation {
                 self?.navigateToOnboarding(avatars: avatars, selectedAvatar: selectedAvatar, avatarData: avatarData)
             }
         }
@@ -88,7 +88,7 @@ final class LoadingViewController: UIViewController {
             .store(in: &cancellables)
     }
     
-    private func titleLabelAnimation(completion: @escaping (UIViewAnimatingPosition) -> Void) {
+    private func titleLabelAnimation(completion: @escaping () -> Void) {
         guard let superview = titleLabel.superview else { return }
 
         let currentY = superview.convert(titleLabel.frame, to: nil).minY
@@ -108,7 +108,10 @@ final class LoadingViewController: UIViewController {
             self?.activityIndicatorView.alpha = 0
         }
 
-        animator.addCompletion(completion)
+        animator.addCompletion { _ in
+            completion()
+        }
+        
         animator.startAnimation()
     }
     

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewModel.swift
@@ -18,17 +18,14 @@ final class LoadingViewModel: @unchecked Sendable {
     }
     
     @Published var avatarData: Data?
-    @Published var loadingStatus = ""
     
     func fetchAvatars() {
         Task {
             do {
-                loadingStatus = String(localized: "게임 데이터 불러오는 중")
                 avatars = try await avatarRepository.getAvatarUrls()
 
                 guard let randomAvatarUrl = avatars.randomElement() else { return }
                 selectedAvatar = randomAvatarUrl
-                loadingStatus = String(localized: "아바타 이미지 다운로드 중")
 
                 await withTaskGroup(of: Data?.self) { group in
                     avatars.forEach { url in

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
@@ -74,7 +74,6 @@ final class LobbyViewController: UIViewController {
             strokeWidth: 3
         )
 
-
         inviteButton.setConfiguration(
             systemImageName: "square.and.arrow.up",
             imageSize: 30,


### PR DESCRIPTION
## 필수 리뷰어

- 모두...?

## 관련 이슈

- #66

## 완료 및 수정 내역

 - [x] 런치스크린 UI 변경
 - [x] 런치스크린 애니메이션 추가

### 애니메이션 구현

- 로딩이 끝나면 로고 애니메이션이 된 뒤에 메인화면으로 넘어갑니다.
- 하드코딩이 아닌 기기별 대응이 가능하고자 아래와 같이 애니메이션을 구성했습니다. 폰트크기는 어쩔수 없었지만 titleLabel의 위치를 받아와 offset을 이동시키는 방식으로 애니메이션을 구현했습니다.

```swift
    private func titleLabelAnimation(completion: @escaping () -> Void) {
        guard let superview = titleLabel.superview else { return }

        /// superView로부터 현재 위치를 받아옴
        let currentY = superview.convert(titleLabel.frame, to: nil).minY
        let targetY = view.safeAreaInsets.top
                
        /// 폰트 크기 변화
        let scaleFactor: CGFloat = 32 / 80

        /// 변한 폰트의 크기 / 2 (위아래로 줄어드니까 2로 나누어주었음)
        let fontHeightDifference = titleLabel.frame.height * (1 - scaleFactor)
        
        /// 이동할 거리 계산
        let translationY = targetY - currentY - (fontHeightDifference / 2)

        let animator = UIViewPropertyAnimator(duration: 1, dampingRatio: 0.85) { [weak self] in
            self?.titleLabel.transform = CGAffineTransform(translationX: 0, y: translationY)
                .scaledBy(x: scaleFactor, y: scaleFactor)
            
            /// 나머지는 투명하게 해서 자연스럽게 애니메이션이 되도록 유도
            self?.subtitleLabel.alpha = 0
            self?.activityIndicatorView.alpha = 0
        }

        /// navigation을 해주는 부분
        animator.addCompletion { _ in
            completion()
        }
        
        animator.startAnimation()
    }
```

## 스크린샷

<image width="250" src="https://github.com/user-attachments/assets/fc5d1b22-ff00-4b13-b986-331ef3f3ce04">

