### PR TITLE
[hotfix] 키보드 올라올 때 뷰가 다시 그려지는 문제 해결

### DIFF
--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicView.swift
@@ -60,8 +60,10 @@ struct SelectMusicView: View {
                             .tint(.black)
                         }
                         .onAppear {
-                            Task {
-                                await viewModel.fetchNextSearchList(currentMusic: music)
+                            if music == viewModel.searchList.last {
+                                Task {
+                                    await viewModel.fetchNextSearchList(currentMusic: music)
+                                }
                             }
                         }
                     }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
@@ -78,6 +78,7 @@ final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
     
     private func bindSearchTerm() {
         $searchTerm
+            .removeDuplicates() 
             .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
             .sink { [weak self] term in
                 Task { [weak self] in


### PR DESCRIPTION
## 필수 리뷰어
- @Sonny-Kor : 키보드 문제 해결된 부분 확인해 주시면 됩니다.
- @around-forest : 키보드 문제 해결된 부분 확인해 주시면 됩니다.
- @hyunjuntyler : fetchNextSearchList함수 중복 호출 개선 확인해 주시면 됩니다.

## 관련 이슈

- #70 

## 완료 및 수정 내역

 - [x] 키보드 개선
 - [x] 동일 함수 중복 호출 개선

## 테스트 방법 (선택)
- 직접 실행해서 테스트 가능합니다.

## 리뷰 노트

처음에 뷰나 뷰모델을 새로 init하는지 확인했으나, 이상이 없었습니다.
-> 즉, 이전 뷰컨트롤러의 영향은 아니었기에 ObservedObject를 StateObject로 바꾸는 것은 의미가 없다고 판단했습니다.

onAppear 호출 시점을 파악했습니다. 서치뷰를 누를때도 호출되는 것을 확인했습니다.
-> 이를 통해 viewModel.searchList의 값이 바뀌고, 이로 인해 새로그려지는 것을 알 수 있었습니다.

뷰모델에서 viewModel.searchList값이 언제 바뀌는지 체크했습니다.
-> resetSearchList 함수에서 값을 []로 만드는 것을 확인 후 resetSearchList이 언제 호출되는지 파악했습니다.

resetSearchList함수는 퍼블리셔에서 값을 받으면 호출되는 것을 파악했습니다.
-> $searchTerm이 서치뷰에 연결되어있었기에 바로 오류 원인을 찾을 수 있었습니다.
(요즘 combine을 공부하고 있었던 덕분인 것 같기도합니다..)


+ 추가로 @hyunjuntyler 님께서 이전 숲님 PR에 말씀해주셨던 fetchNextSearchList 중복호출도 해결했습니다.

![log](https://github.com/user-attachments/assets/6762cb75-6132-4499-bd3d-7806889ad1cd)


## 스크린샷 (선택)

### [기존에 키보드가 올라오면 List 상단으로 이동하던 모습]

https://github.com/user-attachments/assets/aca131d9-d7fd-4355-b780-8b6603309fa1

### [개선된 모습]

https://github.com/user-attachments/assets/6e460e92-31ac-454c-ab0d-a1f7befe9880
