### PR TITLE
[fix] Navigation Bar Back Button UI 수정

### DIFF
--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
@@ -35,6 +35,7 @@ final class ASButton: UIButton {
         cornerStyle: UIButton.Configuration.CornerStyle = .large,
         baseForegroundColor: UIColor = .white,
         shadowColor: UIColor = .asShadow,
+        shadowHeight: CGFloat = 8,
         strokeColor: UIColor? = nil,
         strokeWidth: CGFloat = 0
     ) {
@@ -49,7 +50,7 @@ final class ASButton: UIButton {
             strokeColor: strokeColor,
             strokeWidth: strokeWidth
         )
-        setShadow(color: shadowColor, width: 0, height: 8)
+        setShadow(color: shadowColor, width: 0, height: shadowHeight)
         applyConfiguration()
     }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GameNavigationController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GameNavigationController.swift
@@ -93,16 +93,22 @@ final class GameNavigationController: @unchecked Sendable {
         let backButton = ASButton()
         backButton.setConfiguration(
             systemImageName: "arrowshape.backward.fill",
+            imageSize: 12,
             backgroundColor: .backButtonBackground,
-            cornerStyle: .medium,
+            cornerStyle: .large,
             baseForegroundColor: .backButtonForeground,
             shadowColor: .backButtonShadow,
+            shadowHeight: 4,
             strokeColor: .backButtonShadow,
             strokeWidth: 3
         )
-        backButton.frame = CGRect(x: 0, y: 0, width: 30, height: 30)
-        backButton.layer.shadowOffset = CGSize(width: 0, height: 2)
+        backButton.translatesAutoresizingMaskIntoConstraints = false
         backButton.addAction(backButtonAction, for: .touchUpInside)
+
+        NSLayoutConstraint.activate([
+            backButton.widthAnchor.constraint(equalToConstant: 32),
+            backButton.heightAnchor.constraint(equalToConstant: 32)
+        ])
 
         viewController.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: backButton)
         viewController.title = setTitle()


### PR DESCRIPTION
## 필수 리뷰어

- nil

## 관련 이슈

- #68 

## 완료 및 수정 내역

 - [x] Navigation Bar Back Button UI 수정

## 테스트 방법 (선택)

## 리뷰 노트
조금 학습해본 결과
Navigation Bar Item은 내부적으로 StackView로 Layout을 관리하고있었고,

기존의 방식은 ASButton Init이후에 Frame을 변경한다고 해도 SetNeedLayout을 호출하지 않는 이상 알아서 Frame을 잡아버리는 문제가 발생하여 size가 다르게 설정되었습니다.

그래서 사이즈를 해결할 수 있는 방법으로

1. ASButton Configuration 내부에 contentInsets으로 Inset으로 조절 하는 방법 
  - 너무 사이드 이펙트가 커질거 같아서 이 방법은 채택하지 않았습니다.
2. ASButton의 Constraint 지정 하는 방법

NavigationBar의 Height는 무조건 44px으로 고정인지라 Button의 Shadow 를 고려해서 사이즈를 일단 피그마랑 최대한 비슷하게 끔 설정하기는 했습니다만
Shadow의 CornerRadius는 깔끔하게 나오지는 않네요,

## 스크린샷 (선택)

<img width=300 src="https://github.com/user-attachments/assets/be5b91e3-ad7e-4649-899b-5a09521dc6fb">
