### PR TITLE
[fix] 방 번호 복사 버튼이 입장할 때 보이지 않는 문제, 방 초대 버튼 이미지 사이즈 축소

### DIFF
--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
@@ -58,6 +58,22 @@ final class LobbyViewController: UIViewController {
                 }
             }
             .store(in: &cancellables)
+        
+        viewmodel.$roomNumber
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] roomNumber in
+            self?.roomNumberButton.setConfiguration(
+                text: "#" + roomNumber,
+                textStyle: .largeTitle,
+                backgroundColor: .roomNumberButton,
+                cornerStyle: .large,
+                baseForegroundColor: .asBlack,
+                shadowColor: .backButtonShadow,
+                strokeColor: .backButtonShadow,
+                strokeWidth: 3
+            )
+        }
+        .store(in: &cancellables)
     }
 
     private func setupUI() {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
@@ -76,7 +76,7 @@ final class LobbyViewController: UIViewController {
 
         inviteButton.setConfiguration(
             systemImageName: "square.and.arrow.up",
-            imageSize: 30,
+            imageSize: 24,
             text: nil,
             backgroundColor: .inviteButton,
             cornerStyle: .large,

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewModel.swift
@@ -11,7 +11,7 @@ final class LobbyViewModel: ObservableObject, @unchecked Sendable {
     private let dataDownloadRepository: DataDownloadRepositoryProtocol
 
     let playerMaxCount = 6
-    private(set) var roomNumber: String = ""
+    @Published var roomNumber: String = ""
     @Published var myId: String?
     @Published var players: [Player] = []
     @Published var host: Player?


### PR DESCRIPTION
## 필수 리뷰어

## 관련 이슈

- #73 

## 완료 및 수정 내역

 - [x] 방 번호 복사 버튼이 방 입장 시 보이지 않는 문제 해결
 - [x] 방 초대 버튼 이미지 사이즈 축소 

## 테스트 방법 (선택)

## 리뷰 노트

* 방 초대 버튼 이미지 사이즈를 24로 일단 축소시켰습니다. (이미지 사이즈도 고정이라 조금 아쉽네요)
* 방 입장 시 ViewModel 의 RoomNumber가 SetupUI() 호출 보다 더 늦게 들어오는 이슈가 있어 보이지 않는 문제를 Binding으로 해결했으나 Button의 SetConfiguration 코드가 중복으로 들어가는 문제가 있긴합니다.. 일단 해결은 했으나 조금 찝찝하네요 Button에서 Text만 Update 하고싶은데 함수를 새로만드는게 좋을까요 ?

## 스크린샷 (선택)
<img width=300 src="https://github.com/user-attachments/assets/50395858-5c91-48fb-905e-5c52f3f8b22e">