### PR TITLE
[feat] 카드 뒷면 UI 개선

### DIFF
--- a/alsongDalsong/ASEntity/ASEntity/Mode.swift
+++ b/alsongDalsong/ASEntity/ASEntity/Mode.swift
@@ -1,4 +1,4 @@
-public enum Mode: String, Codable, CaseIterable, Identifiable {
+public enum Mode: String, Codable, CaseIterable, Identifiable, CustomStringConvertible {
     case humming
     case harmony
     case sync
@@ -85,26 +85,31 @@ public enum Mode: String, Codable, CaseIterable, Identifiable {
 
     public var description: String {
         switch self {
-            case .humming: return "원하는 노래를 선택하고 허밍을 하세요! \n다음 사람부터 당신의 허밍을 따라하게 됩니다."
-            case .harmony: return "각 플레이어는 하나의 파트를 녹음하고, 그 녹음을 합쳐 완벽한 하모니를 만들어야 합니다."
-            case .sync: return "동시에 부르는 음악을 맞추는 모드입니다."
-            case .instant: return "짧은 시간에 최대한의 집중을 요구하는 모드입니다. \n1초동안 랜덤으로 선택된 노래 클립을 듣고, 무엇인지 맞춰야 합니다."
-            case .tts: return "가사만 듣고 노래를 맞추는 모드입니다. \n선택된 노래의 가사를 TTS로 읽어주며, 플레이어는 해당 노래를 맞춰야 합니다."
-        }
-    }
-    
-    public var footerText: String {
-        switch self {
         case .humming:
-            "마지막 친구는 허밍을 듣고 어떤 노래인지 맞출 수 있을까요?"
+            return """
+            노래를 선택하고 허밍으로 시작하세요!  
+            다음 사람은 따라 부르고, 마지막은 정답을 맞춰야 해요.
+            """
         case .harmony:
-            "플레이어들이 녹음한 각각의 음성을 합치면서, 누구의 파트가 가장 잘 어우러지는지 확인하세요"
+            return """
+            각자 파트를 녹음해 하모니를 완성하세요!
+            누구의 파트가 가장 어울릴까요?
+            """
         case .sync:
-            "모두의 목소리가 하나가 되는 순간, 과연 정답은 무엇일까요?"
+            return """
+            모두가 동시에 노래를 부르며 정답을 맞추는 협동 모드!
+            목소리가 하나로 어우러질 때, 과연 정답은?
+            """
         case .instant:
-            "짧은 시간에 어떤 노래인지 맞출 수 있을까요?"
+            return """
+            1초짜리 음악 클립을 듣고 바로 맞추는 집중력 테스트!
+            짧은 순간, 당신의 기억력을 믿어보세요.
+            """
         case .tts:
-            "가사만으로 노래를 떠올릴 수 있을까요?"
+            return """
+            노래 가사만 듣고 어떤 곡인지 맞춰보세요.
+            가사만으로 떠오르는 그 노래, 기억해낼 수 있을까요?
+            """
         }
     }
 

--- a/alsongDalsong/ASEntity/ASEntity/Mode.swift
+++ b/alsongDalsong/ASEntity/ASEntity/Mode.swift
@@ -86,27 +86,27 @@ public enum Mode: String, Codable, CaseIterable, Identifiable, CustomStringConve
     public var description: String {
         switch self {
         case .humming:
-            return """
+            """
             노래를 선택하고 허밍으로 시작하세요!  
             다음 사람은 따라 부르고, 마지막은 정답을 맞춰야 해요.
             """
         case .harmony:
-            return """
+            """
             각자 파트를 녹음해 하모니를 완성하세요!
             누구의 파트가 가장 어울릴까요?
             """
         case .sync:
-            return """
+            """
             모두가 동시에 노래를 부르며 정답을 맞추는 협동 모드!
             목소리가 하나로 어우러질 때, 과연 정답은?
             """
         case .instant:
-            return """
+            """
             1초짜리 음악 클립을 듣고 바로 맞추는 집중력 테스트!
             짧은 순간, 당신의 기억력을 믿어보세요.
             """
         case .tts:
-            return """
+            """
             노래 가사만 듣고 어떤 곡인지 맞춰보세요.
             가사만으로 떠오르는 그 노래, 기억해낼 수 있을까요?
             """

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/SwiftUIComponents/ModeView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/SwiftUIComponents/ModeView.swift
@@ -124,7 +124,8 @@ private extension ModeView {
                         .font(.doHyeon(size: 40))
                     
                     Text(LocalizedStringResource(stringLiteral: viewModel.selectedCard.mode.description))
-                        .font(.doHyeon(size: 18))
+                        .font(.system(size: 18))
+                        .fontWeight(.medium)
                         .lineSpacing(6)
                         .frame(maxHeight: .infinity)
                 }
@@ -144,7 +145,8 @@ private extension ModeView {
                         .font(.system(size: 40, weight: .bold))
                     
                     Text("곧 출시 예정입니다")
-                        .font(.doHyeon(size: 18))
+                        .font(.system(size: 18))
+                        .fontWeight(.medium)
                 }
                 .foregroundColor(.white)
             }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/SwiftUIComponents/ModeView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/SwiftUIComponents/ModeView.swift
@@ -33,9 +33,6 @@ struct ModeView: View {
                 frontCard
             } else {
                 backCard
-                    .overlay(
-                        viewModel.selectedCard.isOpened ? nil : lockedView
-                    )
             }
         }
         .rotation3DEffect(
@@ -43,41 +40,21 @@ struct ModeView: View {
             axis: (x: 0, y: 1, z: 0),
             perspective: 0.5
         )
-        .frame(width: width)
         .onTapGesture {
             withAnimation(.easeInOut(duration: 0.8)) {
                 viewModel.flipCard()
             }
         }
+        .frame(width: width)
     }
 }
 
 private extension ModeView {
-    var lockedView: some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: 30)
-                .fill(.ultraThinMaterial)
-                .overlay(Color.black.opacity(0.4))
-                .clipShape(RoundedRectangle(cornerRadius: 30))
-            VStack(spacing: 12) {
-                Image(systemName: "lock.fill")
-                    .font(.system(size: 30, weight: .bold))
-                    .foregroundColor(.white)
-                
-                Text("곧 출시 예정입니다")
-                    .font(.system(size: 20))
-                    .fontWeight(.bold)
-                    .foregroundColor(.white.opacity(0.8))
-            }
-        }
-    }
-    
     var cardBaseView: some View {
         Image(viewModel.selectedCard.mode.imageName)
             .resizable()
             .scaledToFit()
-            .blur(radius: viewModel.selectedCard.isFaceUp ? 0 : 10)
-            .cornerRadius(30)
+            .clipShape(.rect(cornerRadius: 30, style: .continuous))
             .shadow(color: Color.black.opacity(0.25), radius: 4, x: 0, y: 4)
     }
     
@@ -92,16 +69,18 @@ private extension ModeView {
     }
     
     var frontOverlay: some View {
-        ZStack {
+        VStack {
             VStack(alignment: .leading) {
                 HStack {
                     Image(systemName: "clock")
+                    
                     Text(LocalizedStringResource(stringLiteral: viewModel.selectedCard.mode.duration))
                         .font(.doHyeon(size: 20))
                 }
                 
                 HStack {
                     Image(systemName: "person.fill")
+                    
                     Text(LocalizedStringResource(stringLiteral: viewModel.selectedCard.mode.recommendedPlayers))
                         .font(.doHyeon(size: 20))
                 }
@@ -121,36 +100,53 @@ private extension ModeView {
             }
             .padding(.bottom, 25)
             .padding(.leading, 24)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
+            .frame(maxWidth: .infinity, alignment: .bottomLeading)
         }
         .foregroundStyle(.white)  //TO-DO
     }
     
     var backOverlay: some View {
-        ZStack(alignment: .topLeading) {
-            RoundedRectangle(cornerRadius: 30)
-                .fill(Color.white.opacity(0.05))
-                .overlay(
-                    VStack(alignment: .leading, spacing: 50) {
-                        Text(viewModel.selectedCard.mode.title)
-                            .font(.doHyeon(size: 40))
-                            .padding(.top, 50)
-                        
-                        VStack(alignment: .leading, spacing: 20) {
-                            Text(LocalizedStringResource(stringLiteral: viewModel.selectedCard.mode.description))
-                                .font(.system(size: 16))
-                                .fontWeight(.medium)
-                                .lineSpacing(5)
-                            
-                            Text(LocalizedStringResource(stringLiteral: viewModel.selectedCard.mode.footerText))
-                                .font(.system(size: 13))
-                                .lineSpacing(5)
-                                .opacity(0.7)
-                        }
-                    }
-                        .padding(.horizontal, 28)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                )
+        VStack {
+            if viewModel.selectedCard.isOpened {
+                descriptionView
+            } else {
+                lockedView
+            }
         }
+    }
+    
+    var descriptionView: some View {
+        RoundedRectangle(cornerRadius: 30, style: .continuous)
+            .fill(.ultraThinMaterial)
+            .overlay(alignment: .topLeading) {
+                VStack(alignment: .leading) {
+                    Text(viewModel.selectedCard.mode.title)
+                        .font(.doHyeon(size: 40))
+                    
+                    Text(LocalizedStringResource(stringLiteral: viewModel.selectedCard.mode.description))
+                        .font(.doHyeon(size: 18))
+                        .lineSpacing(6)
+                        .frame(maxHeight: .infinity)
+                }
+                .padding(.vertical, 50)
+                .padding(.horizontal, 28)
+            }
+    }
+    
+    var lockedView: some View {
+        Rectangle()
+            .fill(.ultraThinMaterial)
+            .overlay(Color.black.opacity(0.3))
+            .clipShape(.rect(cornerRadius: 30, style: .continuous))
+            .overlay {
+                VStack(spacing: 12) {
+                    Image(systemName: "lock.fill")
+                        .font(.system(size: 40, weight: .bold))
+                    
+                    Text("곧 출시 예정입니다")
+                        .font(.doHyeon(size: 18))
+                }
+                .foregroundColor(.white)
+            }
     }
 }


### PR DESCRIPTION
## 필수 리뷰어

- @INYEKIM 
- @moral-life 
- @around-forest 
- @Sonny-Kor 

## 관련 이슈

- #78 

## 완료 및 수정 내역

 - [x] 뷰 스타일 변경
 - [x] 뷰 코드 스타일 변경
 - [x] 문구 변경

### 뷰 스타일 변경

- 기존의 카드에 `blur`를 씌워서 `Color.white.opacity(0.05)`를 덮어씌우는 방식과 `.fill(.ultraThinMaterial)`가 혼합되어 있어서 `.fill(.ultraThinMaterial)`로 통합해줬습니다.

```swift
    // 기존 코드
    var cardBaseView: some View {
        Image(viewModel.selectedCard.mode.imageName)
            .resizable()
            .scaledToFit()
            .blur(radius: viewModel.selectedCard.isFaceUp ? 0 : 10)
            .cornerRadius(30)
            .shadow(color: Color.black.opacity(0.25), radius: 4, x: 0, y: 4)
    }

    ZStack(alignment: .topLeading) {
            RoundedRectangle(cornerRadius: 30)
                .fill(Color.white.opacity(0.05))
     ....
     }
```

- 설명 문구 도현체로 바꾸어 주었습니다.
- 미니의 경우 대응되지 않아 차라리 설명부분을 꽉차게 해서 모든 기기 대응가능하게 했습니다.

|변경 전|변경 후|
|--|--|
|<img width="250" src="https://github.com/user-attachments/assets/d925fb7d-b561-44a1-bac0-fa03b951f229" />|<img width="250" src="https://github.com/user-attachments/assets/d082674d-8aca-4b57-add9-5c6d2eacf950" />|

```swift
                VStack(alignment: .leading) {
                    Text(viewModel.selectedCard.mode.title)
                        .font(.doHyeon(size: 40))
                    
                    Text(LocalizedStringResource(stringLiteral: viewModel.selectedCard.mode.description))
                        .font(.doHyeon(size: 18))
                        .lineSpacing(6)
                        .frame(maxHeight: .infinity)
                }
                .padding(.vertical, 50)
                .padding(.horizontal, 28)
```

### 뷰 코드 스타일 변경

- `descriptionView`를 추가해줬습니다.

#### ZStack을 없앴습니다.

- `View`에는 `ZStack`과 `.overlay`가 혼합되어 있었습니다.
- `.overlay`로 통일해주었습니다.

<img width="500" src="https://github.com/user-attachments/assets/39d77630-7d62-4b9a-873e-f215dacbe0e9" />

- 참고 [Youtube: Stop Using ZStack](https://www.youtube.com/watch?v=1bwFFGxTwuI)

### 문구 변경

- 요약해서 정리해봤습니다. (with GPT 🙏)
- 이부분은 자유로운 의견 부탁드립니다.

```swift
    public var description: String {
        switch self {
        case .humming:
            return """
            노래를 선택하고 허밍으로 시작하세요!  
            다음 사람은 따라 부르고, 마지막은 정답을 맞춰야 해요.
            """
        case .harmony:
            return """
            각자 파트를 녹음해 하모니를 완성하세요!
            누구의 파트가 가장 어울릴까요?
            """
        case .sync:
            return """
            모두가 동시에 노래를 부르며 정답을 맞추는 협동 모드!
            목소리가 하나로 어우러질 때, 과연 정답은?
            """
        case .instant:
            return """
            1초짜리 음악 클립을 듣고 바로 맞추는 집중력 테스트!
            짧은 순간, 당신의 기억력을 믿어보세요.
            """
        case .tts:
            return """
            노래 가사만 듣고 어떤 곡인지 맞춰보세요.
            가사만으로 떠오르는 그 노래, 기억해낼 수 있을까요?
            """
        }
    }
```

## 스크린샷

|라이트|다크|
|--|--|
|<image width="250" src="https://github.com/user-attachments/assets/0f10927b-37bf-4871-a3ea-5057c602c1be">|<image width="250" src="https://github.com/user-attachments/assets/7dbe58bb-e939-4e61-812b-f5402eb57cba">|

|폰트 변경 후|
|--|
|<image width="250" src="https://github.com/user-attachments/assets/14f7fb7e-5b48-4bb1-83fe-d0a88c544367">|
