### PR TITLE
[feat] 녹음 패널 UI 수정

### DIFF
--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/SpeechBubbleCell.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/SpeechBubbleCell.swift
@@ -89,7 +89,7 @@ struct SpeechBubbleCell: View {
                     .lineLimit(1)
                 }
         case let .record(record):
-            WaveFormWrapper(columns: record.recordAmplitudes, sampleCount: 24, circleColor: .asForeground, highlightColor: .asGreen)
+            WaveFormWrapper(columns: record.recordAmplitudes, sampleCount: 24, circleColor: .profileViewCircle, highlightColor: .asForeground)
         }
     }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/SpeechBubbleCell.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/SpeechBubbleCell.swift
@@ -35,16 +35,15 @@ struct SpeechBubbleCell: View {
     }
 
     var body: some View {
-        if alignment == .left {
-            HStack(spacing: 12) {
-                avatarView(info: playerInfo)
+        HStack(alignment: .top, spacing: 12) {
+            if alignment == .left {
                 speechBubble
             }
-        }
-        if alignment == .right {
-            HStack(spacing: 12) {
+            
+            avatarView(info: playerInfo)
+            
+            if alignment == .right {
                 speechBubble
-                avatarView(info: playerInfo)
             }
         }
     }
@@ -57,12 +56,12 @@ struct SpeechBubbleCell: View {
                 .frame(height: messageType.bubbleHeight)
                 .frame(maxWidth: .infinity)
                 .background {
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .stroke(lineWidth: 3)
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .stroke(lineWidth: 4)
                         .foregroundStyle(.profileViewCircle)
                 }
                 .background {
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
                         .fill(.asSystem)
                         .shadow(color: .asShadow, radius: 2, y: 4)
                 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/SpeechBubbleCell.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/SpeechBubbleCell.swift
@@ -53,15 +53,19 @@ struct SpeechBubbleCell: View {
     private var speechBubble: some View {
         ZStack {
             contentView
-                .padding(.bottom, 8)
-                .padding(.leading, alignment == .left ? 36 : 0)
-                .frame(width: 230, height: messageType.bubbleHeight)
-                .bubbleStyle(
-                    alignment: alignment,
-                    fillColor: .asSystem,
-                    borderColor: .black,
-                    lineWidth: 5
-                )
+                .padding(12)
+                .frame(height: messageType.bubbleHeight)
+                .frame(maxWidth: .infinity)
+                .background {
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .stroke(lineWidth: 3)
+                        .foregroundStyle(.profileViewCircle)
+                }
+                .background {
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(.asSystem)
+                        .shadow(color: .asShadow, radius: 2, y: 4)
+                }
         }
     }
 
@@ -81,17 +85,11 @@ struct SpeechBubbleCell: View {
                         Text(music.artist)
                             .foregroundStyle(.gray)
                     }
-                    .frame(width: 130)
                     .font(.wantedSansBold(size: 20))
                     .lineLimit(1)
-                    Spacer()
                 }
-            case let .record(record):
-                HStack {
-                    WaveFormWrapper(columns: record.recordAmplitudes, sampleCount: 24, circleColor: .asForeground, highlightColor: .asGreen)
-                        .frame(width: 200)
-                    Spacer()
-                }
+        case let .record(record):
+            WaveFormWrapper(columns: record.recordAmplitudes, sampleCount: 24, circleColor: .asForeground, highlightColor: .asGreen)
         }
     }
 
@@ -121,70 +119,5 @@ struct SpeechBubbleCell: View {
         Image(uiImage: UIImage(data: music.artworkData) ?? UIImage())
             .resizable()
             .aspectRatio(contentMode: .fill)
-    }
-}
-
-struct BubbleShape: Shape {
-    let alignment: MessageAlignment
-
-    func path(in rect: CGRect) -> Path {
-        var path = Path()
-        if alignment == .right {
-            addSpeechTailRight(&path, in: rect)
-            addRoundedBody(&path, in: rect, isRight: true)
-        } else {
-            addRoundedBody(&path, in: rect, isRight: false)
-            addSpeechTailLeft(&path, in: rect)
-        }
-        path.closeSubpath()
-        return path
-    }
-
-    private func addSpeechTailRight(_ path: inout Path, in rect: CGRect) {
-        path.move(to: CGPoint(x: rect.maxX - 40, y: rect.minY))
-        path.addLine(to: CGPoint(x: rect.maxX - 8, y: rect.minY))
-        path.addLine(to: CGPoint(x: rect.maxX - 20, y: rect.minY + 16))
-        path.addLine(to: CGPoint(x: rect.maxX - 40, y: rect.minY))
-    }
-
-    private func addSpeechTailLeft(_ path: inout Path, in rect: CGRect) {
-        path.move(to: CGPoint(x: rect.minX + 8, y: rect.minY))
-        path.addLine(to: CGPoint(x: rect.minX + 40, y: rect.minY))
-        path.addLine(to: CGPoint(x: rect.minX + 20, y: rect.minY + 16))
-        path.addLine(to: CGPoint(x: rect.minX + 8, y: rect.minY))
-    }
-
-    private func addRoundedBody(_ path: inout Path, in rect: CGRect, isRight: Bool) {
-        let xOffset: CGFloat = isRight ? -10 : 20
-        path.addRoundedRect(
-            in: CGRect(x: rect.minX + xOffset, y: rect.minY, width: rect.width - 10, height: rect.height - 10),
-            cornerSize: CGSize(width: 12, height: 12)
-        )
-    }
-}
-
-struct BubbleBackgroundModifier: ViewModifier {
-    let alignment: MessageAlignment
-    let fillColor: Color
-    let borderColor: Color
-    let lineWidth: CGFloat
-
-    func body(content: Content) -> some View {
-        content
-            .background(
-                ZStack {
-                    BubbleShape(alignment: alignment)
-                        .stroke(borderColor, lineWidth: lineWidth)
-                    BubbleShape(alignment: alignment)
-                        .fill(fillColor)
-                        .shadow(color: .asShadow, radius: 0, x: 6, y: 6)
-                }
-            )
-    }
-}
-
-extension View {
-    func bubbleStyle(alignment: MessageAlignment, fillColor: Color, borderColor: Color, lineWidth: CGFloat) -> some View {
-        modifier(BubbleBackgroundModifier(alignment: alignment, fillColor: fillColor, borderColor: borderColor, lineWidth: lineWidth))
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/WaveForm.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/WaveForm.swift
@@ -9,7 +9,7 @@ final class WaveForm: UIView {
     private var circleColor: UIColor
     private var highlightColor: UIColor
 
-    init(numOfColumns: Int = 48, circleColor: UIColor = .white, highlightColor: UIColor = .black) {
+    init(numOfColumns: Int = 24, circleColor: UIColor = .profileViewCircle, highlightColor: UIColor = .black) {
         self.numOfColumns = numOfColumns
         self.circleColor = circleColor
         self.highlightColor = highlightColor
@@ -17,8 +17,8 @@ final class WaveForm: UIView {
     }
 
     required init?(coder: NSCoder) {
-        numOfColumns = 48
-        circleColor = .white
+        numOfColumns = 24
+        circleColor = .profileViewCircle
         highlightColor = .black
         super.init(coder: coder)
     }
@@ -41,7 +41,7 @@ final class WaveForm: UIView {
     }
     
     private func drawVisualizerCircles() {
-        let diameter = bounds.width / CGFloat(2 * numOfColumns + 1)
+        let diameter = bounds.width / CGFloat(numOfColumns + numOfColumns / 2 + 1)
         columnWidth = diameter
         let startingPointY = bounds.midY - diameter / 2
         var startingPointX = bounds.minX + diameter
@@ -57,7 +57,7 @@ final class WaveForm: UIView {
 
             layer.addSublayer(circleLayer)
             columns.append(circleLayer)
-            startingPointX += 2 * diameter
+            startingPointX += diameter * 1.5
         }
     }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/WaveFormWrapper.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/WaveFormWrapper.swift
@@ -14,6 +14,12 @@ struct WaveFormWrapper: UIViewRepresentable {
     func updateUIView(_ uiView: WaveForm, context: Context) {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             uiView.drawColumns(with: columns)
+            
+            for i in 0..<sampleCount {
+                DispatchQueue.main.asyncAfter(deadline: .now() + Double(i) * 0.25) {
+                    uiView.updatePlayingIndex(i)
+                }
+            }
         }
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/AudioHelper.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/AudioHelper.swift
@@ -154,7 +154,7 @@ extension AudioHelper {
     }
 
     private func updatePlayIndex() {
-        cancellable = Timer.publish(every: 0.125, on: .main, in: .common)
+        cancellable = Timer.publish(every: 0.25, on: .main, in: .common)
             .autoconnect()
             .scan(0) { count, _ in
                 count + 1
@@ -278,7 +278,7 @@ extension AudioHelper {
 
     private func calculateAmplitude() {
         Logger.debug("진폭계산 시작")
-        cancellable = Timer.publish(every: 0.125, on: .main, in: .common)
+        cancellable = Timer.publish(every: 0.25, on: .main, in: .common)
             .autoconnect()
             .sink { [weak self] _ in
                 guard let self else { return }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewController.swift
@@ -4,7 +4,7 @@ final class HummingViewController: UIViewController {
     private let progressBar = ProgressBar()
     private let scrollView = UIScrollView()
     private let musicPanel = MusicPanel()
-    private let hummingPanel = RecordingPanel(.asYellow)
+    private let hummingPanel = RecordingPanel()
     private let recordButton = ASButton()
     private let submitButton = ASButton()
     private let submissionStatus = SubmissionStatusView()

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/RecordingPanel/AudioButtonState.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/RecordingPanel/AudioButtonState.swift
@@ -14,7 +14,7 @@ enum AudioButtonState {
     var color: UIColor {
         switch self {
             case .recording: .systemRed
-            default: .white
+            default: .asForeground
         }
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/RecordingPanel/RecordingPanel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/RecordingPanel/RecordingPanel.swift
@@ -119,10 +119,10 @@ final class RecordingPanel: UIView {
     }
 
     private func setupUI() {
-        layer.borderWidth = 3
+        layer.borderWidth = 4
         layer.borderColor = UIColor.profileViewCircle.cgColor
         layer.backgroundColor = UIColor.asSystem.cgColor
-        layer.cornerRadius = 12
+        layer.cornerRadius = 15
         
         layer.shadowColor = UIColor.asShadow.cgColor
         layer.shadowOpacity = 0.5

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/RecordingPanel/RecordingPanel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/RecordingPanel/RecordingPanel.swift
@@ -4,13 +4,11 @@ import UIKit
 final class RecordingPanel: UIView {
     private let playButton = UIButton()
     private let waveFormView = WaveForm()
-    private let customBackgroundColor: UIColor
     private let viewModel = RecordingPanelViewModel()
     private var cancellables = Set<AnyCancellable>()
     var onRecordingFinished: ((Data) -> Void)?
 
-    init(_ color: UIColor = .asMint) {
-        customBackgroundColor = color
+    init() {
         super.init(frame: .zero)
         setupButton()
         setupUI()
@@ -19,7 +17,6 @@ final class RecordingPanel: UIView {
     }
 
     required init?(coder: NSCoder) {
-        customBackgroundColor = .asMint
         super.init(coder: coder)
         setupUI()
         setupLayout()
@@ -88,7 +85,7 @@ final class RecordingPanel: UIView {
         let imageConfig = UIImage.SymbolConfiguration(pointSize: 24, weight: .regular)
         buttonConfiguration.image = viewModel.buttonState.symbol
         buttonConfiguration.preferredSymbolConfigurationForImage = imageConfig
-        buttonConfiguration.baseForegroundColor = .white
+        buttonConfiguration.baseForegroundColor = .asForeground
         buttonConfiguration.contentInsets = .zero
         buttonConfiguration.background.backgroundColorTransformer = UIConfigurationColorTransformer { color in
             color.withAlphaComponent(0.0)
@@ -122,8 +119,16 @@ final class RecordingPanel: UIView {
     }
 
     private func setupUI() {
+        layer.borderWidth = 3
+        layer.borderColor = UIColor.profileViewCircle.cgColor
+        layer.backgroundColor = UIColor.asSystem.cgColor
         layer.cornerRadius = 12
-        layer.backgroundColor = customBackgroundColor.cgColor
+        
+        layer.shadowColor = UIColor.asShadow.cgColor
+        layer.shadowOpacity = 0.5
+        layer.shadowOffset = CGSize(width: 0, height: 4)
+        layer.shadowRadius = 2
+        
         addSubview(playButton)
         addSubview(waveFormView)
     }
@@ -137,10 +142,10 @@ final class RecordingPanel: UIView {
             playButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
             playButton.widthAnchor.constraint(equalToConstant: 32),
 
-            waveFormView.leadingAnchor.constraint(equalTo: playButton.trailingAnchor, constant: 12),
+            waveFormView.leadingAnchor.constraint(equalTo: playButton.trailingAnchor, constant: 8),
             waveFormView.topAnchor.constraint(equalTo: topAnchor, constant: 8),
             waveFormView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8),
-            waveFormView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
+            waveFormView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
         ])
     }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/RecordingPanel/RecordingPanelViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/RecordingPanel/RecordingPanelViewModel.swift
@@ -2,7 +2,7 @@ import Combine
 import Foundation
 
 final class RecordingPanelViewModel: @unchecked Sendable {
-    private let sampleCount: Int = 48
+    private let sampleCount: Int = 24
     @Published var recordedData: Data?
     @Published private(set) var recorderAmplitude: Float = 0.0
     @Published private(set) var buttonState: AudioButtonState = .idle

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingViewController.swift
@@ -4,7 +4,7 @@ final class RehummingViewController: UIViewController {
     private let progressBar = ProgressBar()
     private let scrollView = UIScrollView()
     private let musicPanel = MusicPanel()
-    private let hummingPanel = RecordingPanel(.asMint)
+    private let hummingPanel = RecordingPanel()
     private let recordButton = ASButton()
     private let submitButton = ASButton()
     private let submissionStatus = SubmissionStatusView()


### PR DESCRIPTION
## 필수 리뷰어

- @around-forest 

## 관련 이슈

- #86 

## 완료 및 수정 내역

 - [x] 녹음 패널 수정 (`UIKit`)
 - [x] 결과 화면 수정 (`SwiftUI`)

### 녹음 간격 줄이기

`cancellable = Timer.publish(every: 0.125, on: .main, in: .common)` 이부분이 업데이트 핵심이더군요... `cancellable = Timer.publish(every: 0.25, on: .main, in: .common)` 로 바꿔주었습니다.

### 결과 화면 Animation

- 아래와 같이 `RecordPannel`과 같은 로직으로 `Index`를 음성과 관계없이 그냥 같이 업데이트해주는 방식으로 구현했습니다. 실기기 테스트 시 큰 문제없이 애니메이션이 되는 것 같습니다.

```swift
    func updateUIView(_ uiView: WaveForm, context: Context) {
        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
            uiView.drawColumns(with: columns)
            
            for i in 0..<sampleCount {
                DispatchQueue.main.asyncAfter(deadline: .now() + Double(i) * 0.25) {
                    uiView.updatePlayingIndex(i)
                }
            }
        }
    }
```

|녹음 화면 1|녹음 화면 2|결과 화면|
|--|--|--|
|![IMG_3935](https://github.com/user-attachments/assets/6f0279ad-21f0-422a-9975-e3f7c8061d99)|![IMG_3934](https://github.com/user-attachments/assets/633e8c5a-812d-42b3-b784-aabdcda0d58f)|![IMG_3937](https://github.com/user-attachments/assets/d116750f-f32a-4d9b-a3c2-5d658bdf4481)|

## 리뷰 노트

- `SpeechBubbleCell` 네이밍을 추후에 `RecordingResultCell`과 같은 이름으로 변경이 필요해보입니다. PR을 위해 변경사항을 파악하기 위해 파일 이름을 변경해주지 않았습니다.
- 녹음될때 약간 간격이 커서그런지 부드럽게 업데이트 되는 느낌이 아니라서... 조금 아쉽네요? 이부분 좀더 고민해보겠습니다.

### 추가 수정

|녹음 화면|결과 화면|
|--|--|
|<image width="250" src="https://github.com/user-attachments/assets/d1b8f22a-a565-478b-8880-4b911593f4ea">|<image width="250" src="https://github.com/user-attachments/assets/56578b00-41a9-48dc-8a2a-e7ea1ecc52d2">|

### 추가 노트

- 참고로 아바타 이미지 넘기는거 성공했습니다! (코드 한줄 ㅎㅎ) 추후 PR에 올리겠슴다

<image width="250" src="https://github.com/user-attachments/assets/74b6d7da-d573-48e7-8d1e-ae06a75a27e4">
