### PR TITLE
[fix] 다크모드 개선, ProgressBar 20초 밑으로 내려가면 햅틱 + 애니메이션 + 색상변경

### DIFF
--- a/alsongDalsong/alsongDalsong/alsongDalsong/Resources/Assets.xcassets/inviteButton.colorset/Contents.json
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Resources/Assets.xcassets/inviteButton.colorset/Contents.json
@@ -4,10 +4,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "1.000",
-          "blue" : "0.851",
-          "green" : "0.851",
-          "red" : "0.851"
+          "alpha" : "0.690",
+          "blue" : "0xD9",
+          "green" : "0xD9",
+          "red" : "0xD9"
         }
       },
       "idiom" : "universal"

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
@@ -48,7 +48,9 @@ final class ASButton: UIButton {
             cornerStyle: cornerStyle,
             baseForegroundColor: baseForegroundColor,
             strokeColor: strokeColor,
-            strokeWidth: strokeWidth
+            strokeWidth: strokeWidth,
+            shadowColor: shadowColor,
+            shadowHeight: shadowHeight
         )
         setShadow(color: shadowColor, width: 0, height: shadowHeight)
         applyConfiguration()
@@ -64,21 +66,24 @@ final class ASButton: UIButton {
             text: type?.text,
             textStyle: type?.textStyle ?? .largeTitle,
             backgroundColor: type?.backgroundColor,
-            cornerStyle: type?.cornerStyle ?? .medium
+            cornerStyle: type?.cornerStyle ?? .medium,
+            shadowColor: type?.shadowColor ?? .buttonShadowOfDefault,
+            shadowHeight: shadowHeight
         )
         setShadow(color: (type?.shadowColor) ?? .buttonShadowOfDefault, width: 0, height: shadowHeight)
         applyConfiguration()
     }
 
     func bind(
-        to dataSource: Published<Data?>.Publisher,
-        baseBackgroundColor: UIColor = .asGreen
+        to dataSource: Published<Data?>.Publisher
     ) {
         dataSource
             .receive(on: DispatchQueue.main)
             .compactMap { $0 }
             .sink { [weak self] _ in
-                self?.setConfiguration(backgroundColor: baseBackgroundColor, shadowColor: .buttonShadowOfGreen)
+                let backgroundColor = self?.configurationData?.backgroundColor
+                let shadowColor = self?.configurationData?.shadowColor ?? .buttonShadowOfDefault
+                self?.setConfiguration(backgroundColor: backgroundColor, shadowColor: shadowColor)
                 self?.isEnabled = true
             }
             .store(in: &cancellables)
@@ -86,6 +91,7 @@ final class ASButton: UIButton {
 
     /// 버튼을 비활성화하면서 스타일을 변경하는 메서드입니다.
     func setDisabledState() {
+        let previousConfiguration = configurationData
         configurationData = ASButtonConfiguration(
             systemImageName: configurationData?.systemImageName,
             text: configurationData?.text,
@@ -97,6 +103,7 @@ final class ASButton: UIButton {
         setShadow(color: .buttonShadowOfDefault, width: 0)
         isEnabled = false
         applyConfiguration()
+        configurationData = previousConfiguration
     }
 
     enum ASButtonType {
@@ -111,39 +118,36 @@ final class ASButton: UIButton {
 
         var text: String {
             switch self {
-                case .needMorePlayers: String(localized: "게임 인원 부족")
-                case .startRecord: String(localized: "녹음하기")
-                case .recording: String(localized: "녹음중")
-                case .reRecord: String(localized: "재녹음")
-                case .complete: String(localized: "완료")
-                case .submit: String(localized: "제출하기")
-                case .submitted: String(localized: "제출 완료")
-                case .startGame: String(localized: "시작하기!")
-                case .startWaiting: String(localized: "시작 대기 중")
-                case .endWaiting: String(localized: "종료 대기 중")
-                case .next: String(localized: "다음으로")
-                case .nextResultWaiting: String(localized: "다음 결과 대기 중")
+            case .needMorePlayers: String(localized: "게임 인원 부족")
+            case .startRecord: String(localized: "녹음하기")
+            case .recording: String(localized: "녹음중")
+            case .reRecord: String(localized: "재녹음")
+            case .complete: String(localized: "완료")
+            case .submit: String(localized: "제출하기")
+            case .submitted: String(localized: "제출 완료")
+            case .startGame: String(localized: "시작하기!")
+            case .startWaiting: String(localized: "시작 대기 중")
+            case .endWaiting: String(localized: "종료 대기 중")
+            case .next: String(localized: "다음으로")
+            case .nextResultWaiting: String(localized: "다음 결과 대기 중")
             }
         }
 
         var systemImage: String? {
             switch self {
-                case .startGame, .next: "play.fill"
-                case .reRecord: "arrow.clockwise"
-                default: nil
+            case .startGame, .next: "play.fill"
+            case .reRecord: "arrow.clockwise"
+            default: nil
             }
         }
 
         var backgroundColor: UIColor? {
             switch self {
-                case .startRecord: .asLightRed
-                case .recording: .asLightRed
-                case .reRecord: .asLightRed
-                case .complete: .asYellow
-                case .submit: .asLightSky
-                case .startGame, .next: .asLightRed
-                case .endWaiting, .nextResultWaiting, .needMorePlayers: .systemGray2
-                default: nil
+            case .startRecord, .recording, .reRecord, .startGame, .next, .submitted: .asLightRed
+            case .complete: .asLightSky
+            case .submit: .asLightSky
+            case .endWaiting, .nextResultWaiting, .needMorePlayers: .systemGray2
+            default: nil
             }
         }
 
@@ -157,16 +161,26 @@ final class ASButton: UIButton {
 
         var shadowColor: UIColor? {
             switch self {
-            case .startRecord, .recording, .reRecord, .startGame, .next:
-                    .buttonShadowOfRed
-            case .complete:
-                    .buttonShadowOfYellow
-            case .submit:
-                    .buttonShadowOfBlue
-            case .submitted:
-                    .buttonShadowOfGreen
+            case .startRecord, .recording, .reRecord, .startGame, .next, .submitted:
+                .buttonShadowOfRed
+            case .submit, .complete:
+                .buttonShadowOfBlue
             default: nil
             }
+        }
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        guard traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) else { return }
+        guard isEnabled else {
+            setShadow(color: .buttonShadowOfDefault, width: 0)
+            return
+        }
+        if let shadowColor = configurationData?.shadowColor {
+            let resolved = shadowColor.resolvedColor(with: traitCollection)
+            setShadow(color: resolved, width: 0)
         }
     }
 }
@@ -180,17 +194,16 @@ private extension ASButton {
     /// 버튼이 눌렸을 때 효과를 적용하는 메서드
     func applyHighlightEffect() {
         if isHighlighted {
-            transform = CGAffineTransform(translationX: 0, y: 8)
+            transform = CGAffineTransform(translationX: 0, y: configurationData?.shadowHeight ?? 8)
             layer.shadowOffset = .zero
         } else {
             transform = .identity
-            layer.shadowOffset = CGSize(width: 0, height: 8)
+            layer.shadowOffset = CGSize(width: 0, height: configurationData?.shadowHeight ?? 8)
         }
     }
 
     /// 버튼 초기설정을 담당하는 메서드
     func setupButton() {
-        setShadow()
         configurationUpdateHandler = { [weak self] _ in
             self?.applyHighlightEffect()
         }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButtonConfiguration.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButtonConfiguration.swift
@@ -13,6 +13,8 @@ extension ASButton {
         let baseForegroundColor: UIColor
         let strokeColor: UIColor?
         let strokeWidth: CGFloat
+        let shadowColor: UIColor?
+        let shadowHeight: CGFloat
       
         init(
             systemImageName: String? = nil,
@@ -24,7 +26,9 @@ extension ASButton {
             cornerStyle: UIButton.Configuration.CornerStyle = .medium,
             baseForegroundColor: UIColor = .white,
             strokeColor: UIColor? = nil,
-            strokeWidth: CGFloat = 0
+            strokeWidth: CGFloat = 0,
+            shadowColor: UIColor? = nil,
+            shadowHeight: CGFloat = 8
         ) {
             self.systemImageName = systemImageName
             self.imageSize = imageSize
@@ -36,6 +40,8 @@ extension ASButton {
             self.baseForegroundColor = baseForegroundColor
             self.strokeColor = strokeColor
             self.strokeWidth = strokeWidth
+            self.shadowColor = shadowColor
+            self.shadowHeight = shadowHeight
         }
         
         /// 버튼의 스타일을 만드는 메소드

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ProgressBar.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ProgressBar.swift
@@ -4,25 +4,27 @@ import UIKit
 final class ProgressBar: UIView {
     private let progressBar = UIView()
     private var cancellables = Set<AnyCancellable>()
+    
+    private var shakeTimer: Timer?
+    private var shakeWorkItem: DispatchWorkItem?
+    
     private var targetDate: Date?
     private var progressBarWidthConstraint: NSLayoutConstraint?
-
     typealias CompletionHandler = () -> Void
     private var completionHandler: CompletionHandler?
     private var isCancelled = false
-    private var didSetInitialWidth = false
     private var isAnimating = false
-
+    
     init() {
         super.init(frame: .zero)
         setupProgressBar()
     }
-
+    
     @available(*, unavailable)
     required init?(coder _: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
+    
     func bind(
         to dataSource: Published<Date?>.Publisher
     ) {
@@ -34,60 +36,99 @@ final class ProgressBar: UIView {
             }
             .store(in: &cancellables)
     }
-
+    
     override func layoutSubviews() {
         super.layoutSubviews()
-        
-        guard !didSetInitialWidth, !isAnimating else { return }
-        
-        progressBarWidthConstraint?.constant = bounds.width
-        didSetInitialWidth = true
+        if !isAnimating {
+            progressBarWidthConstraint?.constant = bounds.width
+        }
     }
-
-    func setCompletionHandler(_ handler: @escaping CompletionHandler) {
-        completionHandler = handler
-    }
-
-    func cancelCompletion() {
-        isCancelled = true
-    }
-
+    
     private func setupProgressBar() {
         progressBar.backgroundColor = .asYellow
         addSubview(progressBar)
-
+        
         progressBar.translatesAutoresizingMaskIntoConstraints = false
         progressBarWidthConstraint = progressBar.widthAnchor.constraint(equalToConstant: 0)
         NSLayoutConstraint.activate([
+            progressBar.leadingAnchor.constraint(equalTo: leadingAnchor),
             progressBar.topAnchor.constraint(equalTo: topAnchor),
             progressBar.bottomAnchor.constraint(equalTo: bottomAnchor),
-            progressBar.leadingAnchor.constraint(equalTo: leadingAnchor),
-            progressBarWidthConstraint!,
+            progressBarWidthConstraint!
         ])
     }
+    
+    func setCompletionHandler(_ handler: @escaping () -> Void) {
+        completionHandler = handler
+    }
+    
+    func cancelCompletion() {
+        isCancelled = true
+        shakeWorkItem?.cancel()
+        shakeTimer?.invalidate()
+        shakeTimer = nil
+    }
+    
+    // MARK: - 진행 애니메이션 + shake 예약
 
     private func startProgressAnimation() {
         guard let targetDate else { return }
-        let timeInterval = targetDate.timeIntervalSince(Date.now)
+        let remaining = targetDate.timeIntervalSince(Date())
+        guard remaining > 0 else { return }
+        
         cancellables.forEach { $0.cancel() }
         cancellables.removeAll()
+        shakeWorkItem?.cancel()
+        isCancelled = false
         isAnimating = true
         
+        progressBarWidthConstraint?.constant = bounds.width
+        layoutIfNeeded()
+        
+        if remaining > 20 {
+            let workItem = DispatchWorkItem { [weak self] in
+                guard let self else { return }
+                shakeTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
+                    guard let self else { return }
+                    Task { @MainActor in
+                        guard !self.isCancelled else { return }
+                        HapticManager.shared.impact(style: .light)
+                        self.performShakeAnimation()
+                    }
+                }
+                RunLoop.main.add(shakeTimer ?? Timer(), forMode: .common)
+            }
+            shakeWorkItem = workItem
+            DispatchQueue.main.asyncAfter(deadline: .now() + (remaining - 20), execute: workItem)
+        }
+        
         UIView.animate(
-            withDuration: timeInterval,
+            withDuration: remaining,
             delay: 0,
             options: .curveLinear,
-            animations: {
-                self.isAnimating = false
-                self.progressBarWidthConstraint?.constant = 0
-                self.layoutIfNeeded()
+            animations: { [weak self] in
+                guard let self else { return }
+                progressBarWidthConstraint?.constant = 0
+                progressBar.backgroundColor = .asLightRed
+                layoutIfNeeded()
             },
-            completion: { _ in
-                if !self.isCancelled {
-                    self.completionHandler?()
-                    return
+            completion: { [weak self] _ in
+                guard let self else { return }
+                if !isCancelled {
+                    completionHandler?()
                 }
             }
         )
+    }
+    
+    // MARK: - shake 애니메이션 정의
+
+    private func performShakeAnimation() {
+        let animation = CAKeyframeAnimation(keyPath: "transform.translation.y")
+        animation.values = [-10, 10, -8, 8, -5, 5, 0]
+        animation.keyTimes = [0, 0.14, 0.28, 0.42, 0.56, 0.7, 1]
+        animation.duration = 0.6
+        animation.timingFunction = CAMediaTimingFunction(name: .linear)
+        layer.add(animation, forKey: "shake")
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ProgressBar.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ProgressBar.swift
@@ -88,7 +88,7 @@ final class ProgressBar: UIView {
         if remaining > 20 {
             let workItem = DispatchWorkItem { [weak self] in
                 guard let self else { return }
-                shakeTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
+                shakeTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
                     guard let self else { return }
                     Task { @MainActor in
                         guard !self.isCancelled else { return }
@@ -125,9 +125,9 @@ final class ProgressBar: UIView {
 
     private func performShakeAnimation() {
         let animation = CAKeyframeAnimation(keyPath: "transform.translation.y")
-        animation.values = [-10, 10, -8, 8, -5, 5, 0]
-        animation.keyTimes = [0, 0.14, 0.28, 0.42, 0.56, 0.7, 1]
-        animation.duration = 0.6
+        animation.values   = [-5, 5, -4, 4, -2, 2, 0]
+        animation.keyTimes = [0, 0.15, 0.3, 0.45, 0.6, 0.75, 1]
+        animation.duration = 0.4
         animation.timingFunction = CAMediaTimingFunction(name: .linear)
         layer.add(animation, forKey: "shake")
     }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
@@ -66,9 +66,9 @@ final class LobbyViewController: UIViewController {
                 text: "#" + roomNumber,
                 textStyle: .largeTitle,
                 backgroundColor: .roomNumberButton,
-                cornerStyle: .large,
                 baseForegroundColor: .asForeground,
                 shadowColor: .buttonShadowWithLine,
+                shadowHeight: 4,
                 strokeColor: .buttonShadowWithLine,
                 strokeWidth: 3
             )
@@ -83,9 +83,9 @@ final class LobbyViewController: UIViewController {
             text: "#" + viewmodel.roomNumber,
             textStyle: .largeTitle,
             backgroundColor: .roomNumberButton,
-            cornerStyle: .large,
             baseForegroundColor: .asForeground,
             shadowColor: .buttonShadowWithLine,
+            shadowHeight: 4,
             strokeColor: .buttonShadowWithLine,
             strokeWidth: 3
         )
@@ -95,9 +95,9 @@ final class LobbyViewController: UIViewController {
             imageSize: 24,
             text: nil,
             backgroundColor: .inviteButton,
-            cornerStyle: .large,
             baseForegroundColor: .tintColor,
-            shadowColor: .buttonShadowOfDefault
+            shadowColor: .buttonShadowOfDefault,
+            shadowHeight: 4
         )
 
         startButton.setConfiguration(

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewController.swift
@@ -37,7 +37,7 @@ final class SelectMusicViewController: UIViewController {
     
     private func setupUI() {
         view.backgroundColor = .asBackground
-        submitButton.setConfiguration(text: String(localized: "선택 완료"), backgroundColor: .asGreen, shadowColor: .buttonShadowOfGreen)
+        submitButton.setConfiguration(text: String(localized: "선택 완료"), backgroundColor: .asLightRed, shadowColor: .buttonShadowOfRed)
         submitButton.setDisabledState()
         let musicView = SelectMusicView(viewModel: viewModel)
         selectMusicView = UIHostingController(rootView: musicView)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewController.swift
@@ -43,8 +43,8 @@ final class SubmitAnswerViewController: UIViewController {
     }
 
     private func setupUI() {
-        selectAnswerButton.setConfiguration(text: String(localized: "정답 선택"), backgroundColor: .asLightSky, shadowColor: .buttonShadowOfBlue)
-        submitButton.setConfiguration(text: String(localized: "정답 제출"), backgroundColor: .asBackground, shadowColor: .buttonShadowOfGreen)
+        selectAnswerButton.setConfiguration(text: String(localized: "정답 선택"), backgroundColor: .asLightRed, shadowColor: .buttonShadowOfRed)
+        submitButton.setConfiguration(text: String(localized: "정답 제출"), backgroundColor: .asLightSky, shadowColor: .buttonShadowOfBlue)
         submitButton.setDisabledState()
         buttonStack.axis = .horizontal
         buttonStack.spacing = 16


### PR DESCRIPTION
## 필수 리뷰어
nil
## 관련 이슈

- #84 

## 완료 및 수정 내역

 - [x] 다크모드 개선
 - [x] ProgressBar 가 20초 남았을 때 햅틱 + 에니메이션 + 색상변경 처리

## 리뷰 노트
* shadow가 cgColor로 적용되어 항상 불변한 색상으로 적용되고 있다는 것을 파악하고 traitCollectionDidChange를 Override 해서 처리했습니다.
## 스크린샷 (선택)

### 수정 전
<img width=300 src="https://github.com/user-attachments/assets/69ecbaec-3663-457e-a7a9-f321482fcb5f">

### 수정 후 (좀더 덜 흔들리고 빠르게) 

<img width=300 src="https://github.com/user-attachments/assets/8291d49d-ea4f-4a32-adcc-55723aabf92f">