### PR TITLE
[feat] 로딩 뷰에서 너무 오랜 시간동안 다운로드가 걸리는 경우 재시도 및 네트워크 연결 확인 로직 추가

### DIFF
--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/Alert/ASAlertController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/Alert/ASAlertController.swift
@@ -143,6 +143,7 @@ enum ASAlertText {
         case receiveKick
         case notPlayable
         case networkConnectionLost
+        case downloadFailed
 
         var description: String {
             switch self {
@@ -157,6 +158,7 @@ enum ASAlertText {
                 case .receiveKick: "강퇴 되었습니다."
                 case .notPlayable: "다른 플레이어가 모두 방에서 나가 더이상 진행할 수 없습니다\n게임을 종료합니다"
                 case .networkConnectionLost: "네트워크 연결이 끊어졌습니다\n앱을 중단하면 방에서 나가지니 조심하세요!"
+                case .downloadFailed: "게임에 필요한 데이터를 다운받는데 실패했습니다\n네트워크 상태를 확인 후 다시 시도해주세요"
             }
         }
     }
@@ -170,6 +172,7 @@ enum ASAlertText {
         case back
         case setting
         case kick
+        case retry
 
         var description: String {
             switch self {
@@ -181,6 +184,7 @@ enum ASAlertText {
                 case .back: "뒤로가기"
                 case .setting: "설정 가기"
                 case .kick: "강퇴 하기"
+                case . retry: "재시도"
             }
         }
     }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/NetworkMonitor.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/NetworkMonitor.swift
@@ -1,0 +1,20 @@
+import Network
+
+final class NetworkMonitor: @unchecked Sendable {
+    static let shared = NetworkMonitor()
+    private let monitor = NWPathMonitor()
+    private let queue = DispatchQueue(label: "NetworkMonitorQueue")
+    
+    private(set) var isConnected: Bool = false
+    
+    private init() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            self?.isConnected = (path.status == .satisfied)
+        }
+        monitor.start(queue: queue)
+    }
+    
+    func stopMonitoring() {
+        monitor.cancel()
+    }
+}

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/Timeout.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/Timeout.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public struct TimeoutError: LocalizedError {
+    public var errorDescription: String?
+
+    init(_ description: String) {
+        self.errorDescription = description
+    }
+}
+
+public func withThrowingTimeout<T: Sendable>(
+    seconds: TimeInterval,
+    operation: @Sendable @escaping () async throws -> T
+) async throws -> T {
+    try await withThrowingTaskGroup(of: T.self) { group in
+        group.addTask {
+            try await operation()
+        }
+        group.addTask {
+            try await Task.sleep(for: .seconds(seconds))
+            throw TimeoutError.init("네트워크 요청이 너무 오래 걸립니다.")
+        }
+        let result = try await group.next()!
+        group.cancelAll()
+        return result
+    }
+}

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewController.swift
@@ -79,6 +79,13 @@ final class LoadingViewController: UIViewController {
                 self?.navigateToOnboarding(avatars: avatars, selectedAvatar: selectedAvatar, avatarData: avatarData)
             }
         }
+        
+        bind(viewModel?.$failedToDataDownload) { [weak self] isFailed in
+            guard let self else { return }
+            if isFailed {
+                self.showRetryAlert()
+            }
+        }
     }
     
     private func bind<T>(
@@ -149,5 +156,20 @@ final class LoadingViewController: UIViewController {
         Task {
             await AVCaptureDevice.requestAccess(for: .audio)
         }
+    }
+}
+
+// MARK: - Alert
+
+extension LoadingViewController {
+    func showRetryAlert() {
+        let alert = SingleButtonAlertController(
+            titleText: .downloadFailed,
+            primaryButtonText: .retry
+        ) { [weak self] _ in
+                self?.viewModel?.fetchAvatars()
+                self?.viewModel?.fetchBgms()
+        }
+        presentAlert(alert)
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewController.swift
@@ -70,8 +70,8 @@ final class LoadingViewController: UIViewController {
     }
     
     private func bindViewModel() {
-        bind(viewModel?.$avatarData) { [weak self] avatarData in
-            guard let avatarData,
+        bind(viewModel?.$resource) { [weak self] (avatarData, bgmData) in
+            guard let avatarData, bgmData != nil,
                   let avatars = self?.viewModel?.avatars,
                   let selectedAvatar = self?.viewModel?.selectedAvatar else { return }
             

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewModel.swift
@@ -10,6 +10,9 @@ final class LoadingViewModel: @unchecked Sendable {
     private(set) var avatars: [AvatarPair] = []
     private(set) var selectedAvatar: AvatarPair?
 
+    @Published var resource: (avatar: Data?, bgm: Data?)
+    @Published var failedToDataDownload: Bool = false
+
     init(
         avatarRepository: AvatarRepositoryProtocol,
         bgmRepository: BgmRepositoryProtocol,
@@ -21,9 +24,6 @@ final class LoadingViewModel: @unchecked Sendable {
         fetchAvatars()
         fetchBgms()
     }
-
-    @Published var avatarData: Data?
-    @Published var failedToDataDownload: Bool = false
 
     func fetchAvatars() {
         Task {
@@ -43,8 +43,7 @@ final class LoadingViewModel: @unchecked Sendable {
                         }
                     }
                 }
-
-                avatarData = await dataDownloadRepository.downloadData(url: randomAvatarUrl.onboarding)
+                resource.avatar = await dataDownloadRepository.downloadData(url: randomAvatarUrl.onboarding)
             } catch {
                 failedToDataDownload = true
                 ErrorHandler.handle(error)
@@ -62,9 +61,9 @@ final class LoadingViewModel: @unchecked Sendable {
         Task {
             do {
                 failedToDataDownload = false
-                let bgm = try await bgmRepository.getBgmUrl(for: name.rawValue)
-                guard let bgmUrl = bgm else { return }
-                guard let bgmData = await dataDownloadRepository.downloadData(url: bgmUrl) else { return }
+                let bgmUrl = try await bgmRepository.getBgmUrl(for: name.rawValue)
+                guard let bgmUrl, let bgmData = await dataDownloadRepository.downloadData(url: bgmUrl) else { return }
+                resource.bgm = bgmData
                 AudioHelper.shared.addBgmData(name: name, data: bgmData)
             } catch {
                 failedToDataDownload = true

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewModel.swift
@@ -23,10 +23,12 @@ final class LoadingViewModel: @unchecked Sendable {
     }
 
     @Published var avatarData: Data?
+    @Published var failedToDataDownload: Bool = false
 
     func fetchAvatars() {
         Task {
             do {
+                failedToDataDownload = false
                 avatars = try await avatarRepository.getAvatarUrls()
                 guard let randomAvatarUrl = avatars.randomElement() else { return }
                 selectedAvatar = randomAvatarUrl
@@ -44,6 +46,7 @@ final class LoadingViewModel: @unchecked Sendable {
 
                 avatarData = await dataDownloadRepository.downloadData(url: randomAvatarUrl.onboarding)
             } catch {
+                failedToDataDownload = true
                 ErrorHandler.handle(error)
             }
         }
@@ -58,11 +61,13 @@ final class LoadingViewModel: @unchecked Sendable {
     private func addBgm(name: Bgm) {
         Task {
             do {
+                failedToDataDownload = false
                 let bgm = try await bgmRepository.getBgmUrl(for: name.rawValue)
                 guard let bgmUrl = bgm else { return }
                 guard let bgmData = await dataDownloadRepository.downloadData(url: bgmUrl) else { return }
                 AudioHelper.shared.addBgmData(name: name, data: bgmData)
             } catch {
+                failedToDataDownload = true
                 ErrorHandler.handle(error)
             }
         }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewModel.swift
@@ -9,6 +9,7 @@ final class LoadingViewModel: @unchecked Sendable {
     private let dataDownloadRepository: DataDownloadRepositoryProtocol
     private(set) var avatars: [AvatarPair] = []
     private(set) var selectedAvatar: AvatarPair?
+    private let timeoutInterval: TimeInterval = 20.0
 
     @Published var resource: (avatar: Data?, bgm: Data?)
     @Published var failedToDataDownload: Bool = false
@@ -21,29 +22,40 @@ final class LoadingViewModel: @unchecked Sendable {
         self.avatarRepository = avatarRepository
         self.bgmRepository = bgmRepository
         self.dataDownloadRepository = dataDownloadRepository
+        if NetworkMonitor.shared.isConnected {
+            failedToDataDownload = true
+        }
         fetchAvatars()
         fetchBgms()
+    }
+
+    deinit {
+        NetworkMonitor.shared.stopMonitoring()
     }
 
     func fetchAvatars() {
         Task {
             do {
                 failedToDataDownload = false
-                avatars = try await avatarRepository.getAvatarUrls()
+
+                avatars = try await withThrowingTimeout(seconds: timeoutInterval) {
+                    try await self.avatarRepository.getAvatarUrls()
+                }
                 guard let randomAvatarUrl = avatars.randomElement() else { return }
                 selectedAvatar = randomAvatarUrl
 
-                await withTaskGroup(of: (Data?, Data?).self) { group in
-                    for avatar in avatars {
-                        group.addTask { [weak self] in
-                            guard let self else { return (nil, nil) }
-                            async let onboardingData = dataDownloadRepository.downloadData(url: avatar.onboarding)
-                            async let lobbyData = dataDownloadRepository.downloadData(url: avatar.lobby)
-                            return await (onboardingData, lobbyData)
+                try await withThrowingTimeout(seconds: timeoutInterval) {
+                    await withTaskGroup(of: (Data?, Data?).self) { group in
+                        for avatar in self.avatars {
+                            group.addTask {
+                                async let onboardingData = self.dataDownloadRepository.downloadData(url: avatar.onboarding)
+                                async let lobbyData = self.dataDownloadRepository.downloadData(url: avatar.lobby)
+                                return await (onboardingData, lobbyData)
+                            }
                         }
                     }
                 }
-                resource.avatar = await dataDownloadRepository.downloadData(url: randomAvatarUrl.onboarding)
+                resource.avatar = await self.dataDownloadRepository.downloadData(url: randomAvatarUrl.onboarding)
             } catch {
                 failedToDataDownload = true
                 ErrorHandler.handle(error)
@@ -61,10 +73,20 @@ final class LoadingViewModel: @unchecked Sendable {
         Task {
             do {
                 failedToDataDownload = false
-                let bgmUrl = try await bgmRepository.getBgmUrl(for: name.rawValue)
-                guard let bgmUrl, let bgmData = await dataDownloadRepository.downloadData(url: bgmUrl) else { return }
+
+                let bgmUrl = try await withThrowingTimeout(seconds: timeoutInterval) {
+                    try await self.bgmRepository.getBgmUrl(for: name.rawValue)
+                }
+                guard let url = bgmUrl else { return }
+
+                let bgmData = try await withThrowingTimeout(seconds: timeoutInterval) {
+                    await self.dataDownloadRepository.downloadData(url: url)
+                }
+
                 resource.bgm = bgmData
+                guard let bgmData else { failedToDataDownload = true; return }
                 AudioHelper.shared.addBgmData(name: name, data: bgmData)
+
             } catch {
                 failedToDataDownload = true
                 ErrorHandler.handle(error)


### PR DESCRIPTION
## 필수 리뷰어

- nil

## 관련 이슈

- #112 

## 완료 및 수정 내역

 - [x] 로딩 뷰에서 너무 오랜 시간동안 다운로드가 걸리는 경우 재시도 및 네트워크 연결 확인 로직 추가되었습니다.
 - [x] 아바타와 BGM이 모두 다운로드가 완료되었을 경우에만 Onboarding 으로 화면 전환 시키도록 하였습니다. 

## 테스트 방법 (선택)

## 리뷰 노트

- withThrowingTimeout 메서드를 만들었습니다.
```swift
avatars = try await withThrowingTimeout(seconds: timeoutInterval) {
    try await self.avatarRepository.getAvatarUrls()
}
``` 
- Timeout을 몇초로 지정해야할지 논의필요
- Firebase에 AvatarList를 가져오는 API를 TimeOut를 써보니 정상적으로 동작하지 않는 문제점..어찌 NWPathMonitor로 사용해서 해결을 임시조치 해놨습니다. 

## 스크린샷 (선택)

https://github.com/user-attachments/assets/c84467ba-6939-44d5-9f0b-cf6d7fd265ff

