### PR TITLE
[feat] 효과음 재생시 마다 BGM 끊김 현상 해결 

### DIFF
--- a/alsongDalsong/ASAudioKit/ASAudioKit/ASAudioPlayer/ASAudioPlayer.swift
+++ b/alsongDalsong/ASAudioKit/ASAudioKit/ASAudioPlayer/ASAudioPlayer.swift
@@ -21,7 +21,6 @@ public actor ASAudioPlayer: NSObject {
     /// 녹음파일을 재생하고 옵션에 따라 재생시간을 설정합니다.
     public func startPlaying(data: Data, option: PlayType = .full, fade _: Bool = false, isLoop: Bool = false) throws {
         do {
-            try configureAudioSession()
             audioPlayer = try AVAudioPlayer(data: data)
             audioPlayer?.delegate = self
             audioPlayer?.prepareToPlay()
@@ -87,18 +86,6 @@ public actor ASAudioPlayer: NSObject {
 
     public func setOnPlaybackFinished(_ handler: @Sendable @escaping () async -> Void) {
         onPlaybackFinished = handler
-    }
-
-    private func configureAudioSession() throws {
-        do {
-            let session = AVAudioSession.sharedInstance()
-            try session.setCategory(.playAndRecord, mode: .default, options: [.defaultToSpeaker, .mixWithOthers])
-            try session.setActive(true, options: .notifyOthersOnDeactivation)
-        } catch {
-            // TODO: 세션 설정 실패에 따른 처리
-            ErrorHandler.handle(error)
-            throw ASAudioError.configureAudioSession
-        }
     }
 }
 

--- a/alsongDalsong/ASAudioKit/ASAudioKit/ASAudioPlayer/ASAudioPlayer.swift
+++ b/alsongDalsong/ASAudioKit/ASAudioKit/ASAudioPlayer/ASAudioPlayer.swift
@@ -19,12 +19,10 @@ public actor ASAudioPlayer: NSObject {
     }
 
     /// 녹음파일을 재생하고 옵션에 따라 재생시간을 설정합니다.
-    public func startPlaying(data: Data, option: PlayType = .full, volume: Float = 1.0, fade _: Bool = false, isLoop: Bool = false) throws {
+    public func startPlaying(data: Data, option: PlayType = .full, fade _: Bool = false, isLoop: Bool = false) throws {
         do {
             try configureAudioSession()
             audioPlayer = try AVAudioPlayer(data: data)
-            audioPlayer?.volume = volume
-//            audioPlayer?.setVolume(audioPlayer?.volume ?? 0.2, fadeDuration: fade ? 2.0 : 0)
             audioPlayer?.delegate = self
             audioPlayer?.prepareToPlay()
             audioPlayer?.isMeteringEnabled = true
@@ -94,7 +92,7 @@ public actor ASAudioPlayer: NSObject {
     private func configureAudioSession() throws {
         do {
             let session = AVAudioSession.sharedInstance()
-            try session.setCategory(.playAndRecord, mode: .default, options: [.defaultToSpeaker])
+            try session.setCategory(.playAndRecord, mode: .default, options: [.defaultToSpeaker, .mixWithOthers])
             try session.setActive(true, options: .notifyOthersOnDeactivation)
         } catch {
             // TODO: 세션 설정 실패에 따른 처리

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/SceneDelegate.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/SceneDelegate.swift
@@ -62,7 +62,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
     }
 
-    func sceneDidEnterBackground(_: UIScene) {
+    func sceneWillResignActive(_: UIScene) {
         Task {
             await GameAudioHelper.shared.pause()
             await BgmAudioHelper.shared.pause()
@@ -73,6 +73,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let firebaseManager = DIContainer.shared.resolve(ASFirebaseAuthProtocol.self)
         Task {
             do {
+                await BgmAudioHelper.shared.pause()
                 try await firebaseManager.signOut()
             } catch {
                 Logger.error(error.localizedDescription)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/SceneDelegate.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/SceneDelegate.swift
@@ -49,6 +49,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         Task {
             await GameAudioHelper.shared.resume()
+            await BgmAudioHelper.shared.resume()
 
             let isConnected = await firebaseManager.checkConnection()
             if !isConnected {
@@ -64,6 +65,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneDidEnterBackground(_: UIScene) {
         Task {
             await GameAudioHelper.shared.pause()
+            await BgmAudioHelper.shared.pause()
         }
     }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/BgmAudioHelper.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/BgmAudioHelper.swift
@@ -158,7 +158,7 @@ extension BgmAudioHelper {
         switch option {
         case .full:
             do {
-                try await player?.startPlaying(data: file, volume: volume)
+                try await player?.startPlaying(data: file)
             } catch {
                 ErrorHandler.handle(error)
             }
@@ -172,7 +172,7 @@ extension BgmAudioHelper {
             }
         case .loop:
             do {
-                try await player?.startPlaying(data: file, volume: volume, fade: true, isLoop: true)
+                try await player?.startPlaying(data: file, fade: true, isLoop: true)
             } catch {
                 ErrorHandler.handle(error)
             }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/GameAudioHelper.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/GameAudioHelper.swift
@@ -216,7 +216,7 @@ extension GameAudioHelper {
         switch option {
         case .full:
             do {
-                try await player?.startPlaying(data: file, volume: volume)
+                try await player?.startPlaying(data: file)
             } catch {
                 ErrorHandler.handle(error)
             }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/GameAudioHelper.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/GameAudioHelper.swift
@@ -1,5 +1,6 @@
 import ASAudioKit
 import ASLogKit
+import AVFoundation
 import Combine
 import Foundation
 
@@ -7,7 +8,11 @@ final class GameAudioHelper: @unchecked Sendable {
     // MARK: - Singleton
 
     static let shared = GameAudioHelper()
-    private init() {}
+    private init() {
+        do {
+            try configureAudioSession()
+        } catch {}
+    }
 
     // MARK: - Private properties
 
@@ -68,6 +73,17 @@ final class GameAudioHelper: @unchecked Sendable {
 
     var playerEnginePrgressPublisher: AnyPublisher<Double, Never> {
         playerEnginePrgress.eraseToAnyPublisher()
+    }
+
+    private func configureAudioSession() throws {
+        do {
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.playAndRecord, mode: .default, options: [.defaultToSpeaker])
+            try session.setActive(true, options: .notifyOthersOnDeactivation)
+        } catch {
+            // TODO: 세션 설정 실패에 따른 처리
+            ErrorHandler.handle(error)
+        }
     }
 
     var isRecording: Bool {


### PR DESCRIPTION
## 필수 리뷰어

## 관련 이슈

- #117 


## 완료 및 수정 내역
 - [x] BGM 끊김 현상 해결 = configure 코드 한 번만 
 - [x] 볼륨설정 불필요한 코드 삭제 -> 이것을 통해 효과음 재생시 볼륨이 0.5로 올랐다 튀는 현상 해결

## 테스트 방법 (선택)

## 리뷰 노트

```swift
public func startPlaying(data: Data, option: PlayType = .full, fade _: Bool = false, isLoop: Bool = false) throws {
        do {
            try configureAudioSession()  // 플레이시 마다 세션 재설정
            audioPlayer = try AVAudioPlayer(data: data)
            audioPlayer?.volume = volume
```

기존의 ASAudioPlayer 코드를 보면 플레이어를 이용하여 재생을 시키려고 할 때 마다 `configureAudioSession`을 실행하는 것을 볼 수 있습니다. 이 과정때문에 효과음을 재생시키려 할 때마다 세션을 재설정하기 때문에 BGM이 끊기는 것이라 원인 파악을 하게 되었습니다. 따라서 이 세션 설정 하는 부분을 앱 사용중 딱 한번만 사용하게 하는 것이 좋겠다고 판단 하였습니다. (재생만 필요할 때 <-> 재생/녹음 둘 다 필요할 때 두가지를 전환하고자 한다면 configure를 화면마다 적절히 활용하는것이 좋다고도 하나, 그냥 `.playAndRecord`하나만 써도 무리 없이 잘 돌아가기 때문에 생략) 

그리하여 몇가지 방법을 생각하였습니다.

#### 1. SceneDelegate에서 초기화 하여주기 

해당 방법은 Audio와 크게 관련이 없는 부분에서 오디오를 설정한다는 것, 그리고 AVFoundation을 import 하여야 한다는 점이 번거롭고 분리가 되지 않는 것 같아 기각 하였습니다.

#### 2. 플레이어마다 isConfigured 플래그 두고 됐으면 `configureAudioSession()` 더이상 안하게 하기.

플래그 사용하는 것이 좀 안티 패턴 같았고, 실험 결과 처음으로 효과음을 재생시키는 부분에서 끊김 발생함

#### (채택 방법) 3. GameAudioHelper 싱글톤 초기화시 실행

GameAudioHelper 싱글톤 초기화 시 대표로 configureAudioSession 를 하도록 하였습니다. 
다른곳에서 해도 되나 그냥 대표로 이곳에서 실행하도록 하였습니다. 

오디오를 다루는 부분이라는 점, 앱실행시 딱 한번만 실행된다는 점에서 타당하다고 생각하였습니다.
하지만 기존의 Error 를 throw하는 부분이 ASAudioKit - ASAudioError에 있는데 이부분을 읽어오지 못하게 되었습니다. 그러나 handle은 하고있기 때문에 알아 차릴 수 있을 거라 생각해 큰 문제 없다고 생각합니다..


이 밖의 더 좋은 방법 있다거나 수정사항 있으시면 공유 부탁드립니다. 


## 스크린샷 (선택)
