### PR TITLE
[fix] HummingResult  오디오 재생이 정상적이지 않는 문제 해결

### DIFF
--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/BgmAudioHelper.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/BgmAudioHelper.swift
@@ -104,8 +104,6 @@ extension BgmAudioHelper {
     func playBgm() {
         Task {
             print(#function)
-            await GameAudioHelper.shared.stopPlaying()
-            GameAudioHelper.shared.stopEngine()
             await startPlaying(bgmDatas[bgmState], option: .loop, volume: volume)
         }
     }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/GameAudioHelper.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/GameAudioHelper.swift
@@ -127,39 +127,40 @@ extension GameAudioHelper {
         _ data: Data?,
         playType: PlayType = .full
     ) {
-        engineStateSubject.send(false)
         Task {
+            engineStateSubject.send(false)
+            
             guard await player?.isPlaying() == true else { return }
-
+            
             await stopPlaying()
             await BgmAudioHelper.shared.stopPlaying()
-        }
-
-        guard let data else { return }
-
-        Logger.debug(#function)
-
-        playerEngine.bind(data: data)
-
-        switch playType {
-        /// playType에 따라 전체 혹은 부분 재생
-        case .full:
-            playerEngine.play()
-
-        case let .partial(time: time):
-            playerEngine.play()
-
-            DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(time)) { [weak self] in
-                self?.stopEngine()
+            
+            guard let data else { return }
+            
+            Logger.debug(#function)
+            
+            playerEngine.bind(data: data)
+            
+            switch playType {
+                /// playType에 따라 전체 혹은 부분 재생
+            case .full:
+                playerEngine.play()
+                
+            case let .partial(time: time):
+                playerEngine.play()
+                
+                DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(time)) { [weak self] in
+                    self?.stopEngine()
+                }
+                
+            case .loop:
+                playerEngine.play()
             }
-
-        case .loop:
-            playerEngine.play()
+            
+            engineStateSubject.send(true)
+            
+            updateFrequencyAndProgress()
         }
-
-        engineStateSubject.send(true)
-
-        updateFrequencyAndProgress()
     }
 
     func stopEngine() {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/GameAudioHelper.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/GameAudioHelper.swift
@@ -130,35 +130,45 @@ extension GameAudioHelper {
         Task {
             engineStateSubject.send(false)
             
-            guard await player?.isPlaying() == true else { return }
+            if playerEngine.playState == .play {
+                Logger.debug("await playerEngine.playState == .play 의 stopEngine")
+                stopEngine()
+            }
+
+            if await player?.isPlaying() ?? false {
+                Logger.debug("await player?.isPlaying() 의 stopPlaying")
+                await stopPlaying()
+            }
             
-            await stopPlaying()
-            await BgmAudioHelper.shared.stopPlaying()
-            
+            if await BgmAudioHelper.shared.isPlaying {
+                Logger.debug("await BgmAudioHelper.shared.stopPlaying() 의 stopPlaying")
+                await BgmAudioHelper.shared.stopPlaying()
+            }
+
             guard let data else { return }
-            
             Logger.debug(#function)
-            
+
             playerEngine.bind(data: data)
-            
+
             switch playType {
-                /// playType에 따라 전체 혹은 부분 재생
+            /// playType에 따라 전체 혹은 부분 재생
             case .full:
                 playerEngine.play()
-                
+
             case let .partial(time: time):
                 playerEngine.play()
-                
+
                 DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(time)) { [weak self] in
+                    Logger.debug("\(time)후 stopEngine 발동")
                     self?.stopEngine()
                 }
-                
+
             case .loop:
                 playerEngine.play()
             }
-            
+
             engineStateSubject.send(true)
-            
+
             updateFrequencyAndProgress()
         }
     }
@@ -192,7 +202,9 @@ extension GameAudioHelper {
         if playerEngine.playState == .play {
             stopEngine()
         }
-        await BgmAudioHelper.shared.stopPlaying()
+        if await BgmAudioHelper.shared.isPlaying {
+            await BgmAudioHelper.shared.stopPlaying()
+        }
 
         guard await checkRecorderState(), await checkPlayerState() else { return }
         guard let file else { return }
@@ -203,7 +215,7 @@ extension GameAudioHelper {
         await player?.setOnPlaybackFinished { [weak self] in
             await self?.stopPlaying()
         }
-
+        Logger.debug(#function)
         playerStateSubject.send((source, true))
 
         if needsWaveUpdate {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/GameAudioHelper.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/GameAudioHelper.swift
@@ -131,17 +131,14 @@ extension GameAudioHelper {
             engineStateSubject.send(false)
             
             if playerEngine.playState == .play {
-                Logger.debug("await playerEngine.playState == .play 의 stopEngine")
                 stopEngine()
             }
 
             if await player?.isPlaying() ?? false {
-                Logger.debug("await player?.isPlaying() 의 stopPlaying")
                 await stopPlaying()
             }
             
             if await BgmAudioHelper.shared.isPlaying {
-                Logger.debug("await BgmAudioHelper.shared.stopPlaying() 의 stopPlaying")
                 await BgmAudioHelper.shared.stopPlaying()
             }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GameNavigationController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GameNavigationController.swift
@@ -175,25 +175,24 @@ final class GameNavigationController: @unchecked Sendable {
     private func updateViewControllers(state: GameState) {
         let viewType = state.resolveViewType()
         switch viewType {
-            case .submitMusic:
-                navigateToSelectMusic()
+        case .submitMusic: navigateToSelectMusic()
+        case .humming: navigateToHumming()
+        case .rehumming: navigateToRehumming()
+        case .submitAnswer: navigateToSubmitAnswer()
+        case .result: navigateToResult()
+        case .lobby: navigateToLobby()
+        default: break
+        }
+        
+        if viewType == .result {
+            Task {
+                GameAudioHelper.shared.stopEngine()
+                await GameAudioHelper.shared.stopPlaying()
+            }
+        }
+        
+        if viewType != .lobby {
             BgmAudioHelper.shared.changeState(to: .ingame)
-            case .humming:
-                navigateToHumming()
-            BgmAudioHelper.shared.changeState(to: .ingame)
-            case .rehumming:
-                navigateToRehumming()
-            BgmAudioHelper.shared.changeState(to: .ingame)
-            case .submitAnswer:
-                navigateToSubmitAnswer()
-            BgmAudioHelper.shared.changeState(to: .ingame)
-            case .result:
-                navigateToResult()
-            BgmAudioHelper.shared.changeState(to: .ingame)
-            case .lobby:
-                navigateToLobby()
-            default:
-                break
         }
     }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GameNavigationController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GameNavigationController.swift
@@ -184,14 +184,14 @@ final class GameNavigationController: @unchecked Sendable {
         default: break
         }
         
-        if viewType == .result {
+        if viewType != .result {
             Task {
                 GameAudioHelper.shared.stopEngine()
                 await GameAudioHelper.shared.stopPlaying()
             }
         }
         
-        if viewType != .lobby {
+        if viewType != .lobby{
             BgmAudioHelper.shared.changeState(to: .ingame)
         }
     }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Player/AudioPlayerViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Player/AudioPlayerViewModel.swift
@@ -36,10 +36,6 @@ final class AudioPlayerViewModel: @unchecked Sendable {
         bindAudioHelper()
     }
 
-    deinit {
-        GameAudioHelper.shared.stopEngine()
-    }
-
     @MainActor
     func togglePlay() {
         if isPlaying {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewModel.swift
@@ -196,9 +196,8 @@ extension HummingResultViewModel {
                 receiveCompletion: {
                     Logger.debug($0)
                 }, receiveValue: { [weak self] sortedResult in
-                    guard let self,
-                          isValidResult(sortedResult) else { return }
-
+                    guard let self, isValidResult(sortedResult) else { return }
+                    Logger.debug("totalResult fetched")
                     totalResult = sortedResult.map { ($0.answer, $0.records, $0.submit) }
                     updateCurrentResult()
                   })
@@ -211,6 +210,7 @@ extension HummingResultViewModel {
             .receive(on: DispatchQueue.main)
             .dropFirst()
             .sink { [weak self] _, _ in
+                Logger.debug("Player state changed")
                 self?.updateResultPhase()
             }
             .store(in: &cancellables)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewModel.swift
@@ -208,7 +208,6 @@ extension HummingResultViewModel {
         GameAudioHelper.shared.playerStatePublisher
             .filter { _, isPlaying in !isPlaying }
             .receive(on: DispatchQueue.main)
-            .dropFirst()
             .sink { [weak self] _, _ in
                 Logger.debug("Player state changed")
                 self?.updateResultPhase()


### PR DESCRIPTION
## 필수 리뷰어
- nil

## 관련 이슈

- #115 

## 완료 및 수정 내역

 - [x] 원인 : AudioPlayerViewModel 에 deinit 으로  GameAudioHelper.shared.stopEngine() 을 하지않도록 수정하였습니다.
 - [x] Game Navigaiton Controller에서 BGM 재생 로직 간소화
 - [x] GameAudioHelper 의 로직 개선 
   - 현재 BGM이 재생중인지에 대한 상태 검사 후 Stop을 하도록 하였습니다.)
   - 동기적으로 로직이 일어나야 하는 부분에서 비동기로 처리되던 문제 해결
  
## 리뷰 노트

GameAudioHelper의 stopEngine()이나 stopPlaying() 로직 내부에서 값을 Publish 해서 Bind 하는 부분에 문제가 많은 것 같습니다.
정확히 어떤 데이터가 Bind 되는지 알아보기 힘들고, 외부에서 싱글톤으로 멋대로 stopEngine()나 stopPlaying()를 할 때 정말 조심히 사용해야하는 문제가 있어습니다. (특히 결과에서 stop함수를 호출하면 이 되면 다음 노래가 재생이되는데, Bgm 이 추가되면서 State가 엉키게 된 것 같습니다. 

현재는 억지로 문제를 해결했지만 확장성이 많이 떨어지다고 느꼈습니다. 

더 좋은 방법으로 개선이 필요한 것 같습니다. (우선 배포 먼저!!!)
