### PR TITLE
[refactor] LobbyView 문제 해결

### DIFF
--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/SwiftUIComponents/ModeView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/SwiftUIComponents/ModeView.swift
@@ -6,24 +6,17 @@ struct ModeView: View {
     let width: CGFloat
     
     /// 실제로 사용되는 뷰모델
-    var viewModel: ModeViewModel {
-        externalViewModel ?? stateViewModel
-    }
-    
-    @StateObject private var stateViewModel: ModeViewModel
-    private var externalViewModel: ModeViewModel?
+    @ObservedObject private var viewModel: ModeViewModel
     
     /// 외부 값에 의해 뷰가 변경될 경우 사용하는 초기화
     init(mode: Mode, width: CGFloat) {
-        _stateViewModel = StateObject(wrappedValue: ModeViewModel(mode: mode))
-        self.externalViewModel = nil
+        self.viewModel = ModeViewModel(mode: mode)
         self.width = width
     }
     
     /// 외부 뷰에 의해 뷰 모델이 관리되는 경우 사용하는 초기화
     init(viewModel: ModeViewModel, width: CGFloat) {
-        _stateViewModel = StateObject(wrappedValue: viewModel)
-        self.externalViewModel = viewModel
+        self.viewModel = viewModel
         self.width = width
     }
     

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/SwiftUIComponents/ModeViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/SwiftUIComponents/ModeViewModel.swift
@@ -11,7 +11,8 @@ final class ModeViewModel: ObservableObject {
         self.selectedCard = ModeCard(mode: mode, isOpened: isOpened)
     }
     
-    @MainActor func flipCard(delay: TimeInterval = 0.4) {
+    @MainActor
+    func flipCard(delay: TimeInterval = 0.4) {
         HapticManager.shared.impact(style: .medium)
         rotation = (rotation == 0) ? -180 : 0
         

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/SwiftUIComponents/ProfileView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/SwiftUIComponents/ProfileView.swift
@@ -54,6 +54,7 @@ struct ProfileView: View {
                 .padding(.bottom, 8)
             if let name {
                 Text(name)
+                    .frame(height: .responsiveHeight(38), alignment: .top)
                     .foregroundStyle(isMyId ? .asBlue : .asForeground)
                     .font(.doHyeon(size: .responsiveHeight(16)))
                     .multilineTextAlignment(.center)
@@ -61,6 +62,7 @@ struct ProfileView: View {
                     .fixedSize(horizontal: false, vertical: true)
             } else {
                 Text("비어 있음")
+                    .frame(height: .responsiveHeight(38), alignment: .top)
                     .font(.doHyeon(size: .responsiveHeight(16)))
                     .multilineTextAlignment(.center)
                     .lineLimit(nil)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/SwiftUIComponents/ProfileView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/SwiftUIComponents/ProfileView.swift
@@ -5,6 +5,7 @@ struct AsyncImageView: View {
     let imagePublisher: (URL?) async -> Data?
     let url: URL?
     @State private var imageData: Data?
+    @State private var imageID = UUID()
 
     var body: some View {
         Group {
@@ -12,16 +13,24 @@ struct AsyncImageView: View {
                 Image(uiImage: uiImage)
                     .resizable()
                     .aspectRatio(contentMode: .fill)
-                    .transition(.move(edge: .bottom))
+                    .transition(.asymmetric(insertion: .move(edge: .bottom), removal: .identity))
+                    .id(imageID)
             } else {
                 Circle()
                     .fill(.clear)
             }
         }
-        .animation(.linear(duration: 0.5), value: imageData)
+        .animation(.linear(duration: 0.5), value: imageID)
         .onAppear {
             Task {
                 imageData = await imagePublisher(url)
+                imageID = UUID()
+            }
+        }
+        .onChange(of: url) { newURL in
+            Task {
+                imageData = await imagePublisher(newURL)
+                imageID = UUID()
             }
         }
     }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyView.swift
@@ -9,7 +9,7 @@ struct LobbyView: View {
         VStack {
             ScrollView(.horizontal) {
                 HStack(alignment: .top, spacing: .responsiveHeight(16)) {
-                    ForEach(0..<viewModel.playerMaxCount, id: \.self) { index in
+                    ForEach((0..<viewModel.playerMaxCount), id: \.self) { index in
                         if index < viewModel.players.count {
                             let player = viewModel.players[index]
                             if viewModel.isHost, player.id != viewModel.host?.id {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyView.swift
@@ -53,7 +53,6 @@ struct LobbyView: View {
                 }
                 .padding(.horizontal, .responsiveWidth(24))
                 .padding(.top, .responsiveHeight(20))
-                .padding(.bottom, .responsiveHeight(12))
             }
             .padding(.top, .responsiveHeight(8))
             .scrollIndicators(.hidden)
@@ -69,7 +68,7 @@ struct LobbyView: View {
                     }
                 }
             }
-            .padding(.top, .responsiveHeight(10))
+            .padding(.top, .responsiveHeight(8))
         }
         .background(Color.asBackground)
     }


### PR DESCRIPTION
## 필수 리뷰어

- None

## 관련 이슈

- #116

## 완료 및 수정 내역

 - [x] 호스트가 아닌 플레이어의 ModeView가 Tap 됐을 때 설명을 보여주지 않는 문제
 - [x] 플레이어들의 닉네임 길이에 따른 SnapperView/ModeView  밀림 문제
 - [x] (추가) 플레이어(본인) 기준 왼쪽의 플레이어가 나갔을 시 아바타가 변경되지 않는 문제

## 리뷰 노트
### 카드 Tap 문제
ModeView의 ViewModel이 @StateObject로 되어있었습니다. 
@StateObject는 View 내부에서 처음 생성 시 정상 작동하지만(호스트의 경우), 외부에서 init으로 주입 받은 ViewModel을 @StateObject로 감쌌을 때(게스트의 경우) SwiftUI에서 해당 객체의 상태변화를 제대로 감지하지 못하게됩니다.
이로인해 게스트의 ViewModel의 flipCard()가 정상 적동하지 못했습니다.

따라서 기존의

```swift
@StateObject private var stateViewModel: MOodeViewModel
private var externalViewModel: ModeViewModel?
```
을 @ObservedObject로 통합하여 사용하여 ViewModel이 내부 혹은 외부에서 생성되더라도 정상적으로 상태 업데이트를 반영하게 했습니다.

### 뷰 밀림 문제
이것저것 테스트해본 결과 ProfileView의 Text에 고정 세로값 프레임을 설정하고 다른 기타 Padding 및 레이아웃을 조정하는 방법을 선택했습니다. 

### 아바타 변경 문제
AsyncImageView는 SwiftUI가 재생성하지 않으면 onAppear가 재실행되지 않습니다.
그리고 SwiftUI는 상태나 id가 바뀌지 않으면 기존 뷰를 재사용하기 때문에 imageUrl이 변경되어도 AsyncImageView가 새로 만들어지지 않으면 .onAppear가 재실행되지 않습니다.
이로인해 players가 변경되어 ProfileView에 변화가 생겨도 AsyncImageView는 이미 만들어져있고 url의 변화에 따라 재생성하지 않기 때문에 기존의 아바타를 재사용하고 있었습니다.

따라서,

1. .onChange(of: url)로 url 변화를 감지하고
2. id로 image가 다른 이미지인지 확인하여
3. AsyncImageView의 Image를 다시 그리게 했습니다.

여기서 기존 이미지에도 애니메이션이 적용되는 문제(기존 이미지는 아래로, 새 이미지는 위로 올라오는 symmatric 문제)가 발견되어 transition을 asymmetric으로 지정, 생성시에는 애니메이션을 적용하고 삭제시에는 아무런 애니메이션이 적용되지 않게 수정했습니다.

다만, 이제 새로운 이미지에 대한 이미지 변경 및 애니메이션 적용은 잘 작동하지만 예를들어 호스트의 이미지가 1이고 다음 게스트의 이미지도 동일한 1일 경우에는 여전히 SwiftUI가 동일한 이미지로 인식하여 기존 뷰를 재사용하고 이에 따라 애니메이션도 적용되지 않습니다.

## 스크린샷 (선택)

<img width="512" alt="image" src="https://github.com/user-attachments/assets/798e9f25-49bd-4874-9218-9c573bddf5d0" />
