### PR TITLE
[fix] 정답 제출 화면 오류 수정

### DIFF
--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Player/AudioPlayerViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Player/AudioPlayerViewModel.swift
@@ -1,5 +1,6 @@
 import ASAudioKit
 import ASEntity
+import ASLogKit
 import ASRepositoryProtocol
 import Combine
 import Foundation
@@ -16,6 +17,7 @@ final class AudioPlayerViewModel: @unchecked Sendable {
 
     private var cancellables = Set<AnyCancellable>()
 
+    /// 플레이어 init
     init(
         music: Music?,
         dataDownloadRepository: DataDownloadRepositoryProtocol
@@ -24,9 +26,9 @@ final class AudioPlayerViewModel: @unchecked Sendable {
         self.dataDownloadRepository = dataDownloadRepository
         getPreviewData()
         getArtworkData()
-        bindAudioHelper()
     }
 
+    /// 결과화면 init
     init(
         previewData: Data?,
         artworkData: Data?
@@ -39,7 +41,7 @@ final class AudioPlayerViewModel: @unchecked Sendable {
     @MainActor
     func togglePlay() {
         if isPlaying {
-            isPlaying = false
+            self.isPlaying = false
             GameAudioHelper.shared.stopEngine()
             unbindAudioHelper()
         } else {
@@ -68,6 +70,8 @@ final class AudioPlayerViewModel: @unchecked Sendable {
     }
 
     private func bindAudioHelper() {
+        Logger.debug("Bind AudioHelper")
+        
         GameAudioHelper.shared.playerEnginePrgressPublisher
             .receive(on: DispatchQueue.main)
             .sink { self.progress = $0 }
@@ -81,11 +85,15 @@ final class AudioPlayerViewModel: @unchecked Sendable {
         GameAudioHelper.shared.engineStatePublisher
             .receive(on: DispatchQueue.main)
             .sink { state in
-                if self.isPlaying, !state {
+                Logger.debug("Engine State: \(state) | isPlaying: \(self.isPlaying)")
+                
+                if self.isPlaying && !state {
+                    Logger.debug("Unbind AudioHelper")
                     self.unbindAudioHelper()
                 }
 
                 self.isPlaying = state
+                Logger.debug("isPlaying: \(self.isPlaying)")
             }
             .store(in: &cancellables)
     }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewController.swift
@@ -146,10 +146,6 @@ class HummingResultViewController: UIViewController {
             .combineLatest(viewModel.$result, viewModel.$isHost)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] phase, result, isHost in
-                if phase != .answer {
-                    self?.answerView.unbind()
-                }
-                
                 self?.addDataSource(phase, result: result)
                 if result.answer != nil, isHost {
                     self?.changeButton(phase)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SelectAnswerView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SelectAnswerView.swift
@@ -77,6 +77,9 @@ struct SelectAnswerView: View {
                     }
                 }
             }
+            .onDisappear {
+                viewModel.isPlaying.toggle()
+            }
         }
     }
 }


### PR DESCRIPTION
## 필수 리뷰어

- @Sonny-Kor 

## 관련 이슈

- #127 

## 완료 및 수정 내역

 - [x] 음악 선택 시트 내려갈 시 음악 정지
 - [x] 정답 제출 플레이어 재생 오류 수정
 - [x] 결과화면 플레이어 재생 오류 수정

### 문제 상황

- 노래 선택 후 재생시 같이 재생되는 이슈

<image width="250" src="https://github.com/user-attachments/assets/952c2256-7938-41d1-8da3-fe70197a6286">

### 해결 과정

- `player init`에서 `bind`하지 않고, `play`, `stop`을 할때 `bind`, `unbind`하게 해주었습니다.
- 결과뷰의 경우 `init`에서 `bind`합니다.

```swift
    /// 플레이어 init
    init(
        music: Music?,
        dataDownloadRepository: DataDownloadRepositoryProtocol
    ) {
        self.music = music
        self.dataDownloadRepository = dataDownloadRepository
        getPreviewData()
        getArtworkData()
    }

    /// 결과화면 init
    init(
        previewData: Data?,
        artworkData: Data?
    ) {
        self.previewData = previewData
        self.artworkData = artworkData
        bindAudioHelper()
    }

    @MainActor
    func togglePlay() {
        if isPlaying {
            self.isPlaying = false
            GameAudioHelper.shared.stopEngine()
            unbindAudioHelper()
        } else {
            Task {
                await BgmAudioHelper.shared.stopPlaying()
            }
            guard let previewData else { return }

            bindAudioHelper()
            GameAudioHelper.shared.playEngine(previewData)
        }
    }
```

### 수정된 정답 제출 화면

<image width="250" src="https://github.com/user-attachments/assets/d024c635-e50d-4a9c-94a2-50e5094b3d50">

### 결과 화면

<image width="250" src="https://github.com/user-attachments/assets/5f713ce1-fa76-4d48-ad7d-b82379ccf9eb">

## 리뷰 노트

- 음악 플레이 중에 결과로 넘어가게 된다면 결과 화면이 이상하게 되는 것 같아 이부분은 넘어갔을 시 `player engine stop` 해주어야 할 것 같습니다!