### PR TITLE
[fix] 설정 슬라이더 UI 오류 수정

### DIFF
--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASSlider.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASSlider.swift
@@ -1,29 +1,78 @@
 import UIKit
 
-class ASSlider: UISlider {
-    /*
-     // Only override draw() if you perform custom drawing.
-     // An empty implementation adversely affects performance during animation.
-     override func draw(_ rect: CGRect) {
-         // Drawing code
-     }
-     */
+final class ASSlider: UISlider {
+    private let trackLayer = CALayer()
+    private let fillLayer = CALayer()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupUI()
+    }
+    
     override func trackRect(forBounds bounds: CGRect) -> CGRect {
-        return CGRect(origin: bounds.origin, size: CGSize(width: bounds.width, height: .responsiveHeight(20)))
+        let trackHeight: CGFloat = .responsiveHeight(20)
+        
+        return CGRect(
+            x: bounds.origin.x,
+            y: (bounds.height - trackHeight) / 2,
+            width: bounds.width,
+            height: trackHeight
+        )
     }
     
-    override func minimumValueImageRect(forBounds bounds: CGRect) -> CGRect {
-        // 원하는 위치와 크기로 조정
-        return CGRect(x: bounds.minX - 40, y: bounds.minY, width: 30, height: 20)
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        let trackRect = trackRect(forBounds: bounds)
+        trackLayer.frame = trackRect
+        updateFillLayer()
+        
+        if let thumbView = subviews.last {
+            bringSubviewToFront(thumbView)
+        }
     }
     
-    override func maximumValueImageRect(forBounds bounds: CGRect) -> CGRect {
-        return CGRect(x: bounds.maxX + 10, y: bounds.minY, width: 30, height: 20)
+    private func setupUI() {
+        /// 기본 track 숨김
+        setMinimumTrackImage(UIImage(), for: .normal)
+        setMaximumTrackImage(UIImage(), for: .normal)
+        
+        trackLayer.backgroundColor = UIColor.systemGray5.cgColor
+        trackLayer.cornerRadius = .responsiveHeight(20) / 2
+        layer.addSublayer(trackLayer)
+        
+        fillLayer.backgroundColor = UIColor.asBlue.cgColor
+        fillLayer.cornerRadius = .responsiveHeight(20) / 2
+        layer.addSublayer(fillLayer)
+        
+        addTarget(self, action: #selector(valueChanged), for: .valueChanged)
     }
-
-    func setUI() {
-        minimumTrackTintColor = .asOrange
-        minimumValueImage = UIImage(systemName: "speaker.wave.1.fill")
-        maximumValueImage = UIImage(systemName: "speaker.wave.3.fill")
+    
+    private func updateFillLayer() {
+        /// frame update 시 자동으로 애니메이션이 되어 애니메이션 제거
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        
+        let trackRect = trackRect(forBounds: bounds)
+        let thumbRect = thumbRect(forBounds: bounds, trackRect: trackRect, value: value)
+        let fillWidth = thumbRect.midX - trackRect.origin.x
+        
+        fillLayer.frame = CGRect(
+            x: trackRect.origin.x,
+            y: trackRect.origin.y,
+            width: fillWidth,
+            height: trackRect.height
+        )
+        
+        CATransaction.commit()
+    }
+    
+    @objc private func valueChanged() {
+        updateFillLayer()
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Setting/SettingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Setting/SettingViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class SettingViewController: UIViewController {
+final class SettingViewController: UIViewController {
     var settingView = ASPanel()
     var stackView = UIStackView()
     var titleLabel = UILabel()
@@ -151,4 +151,9 @@ class SettingViewController: UIViewController {
     @objc func changeEffectSlider() {
         EffectAudioHelper.shared.changeVolume(effectSlider.value)
     }
+}
+
+@available(iOS 17.0, *)
+#Preview {
+    SettingViewController()
 }


### PR DESCRIPTION
## 필수 리뷰어

- @moral-life 

## 관련 이슈

- #132 

## 완료 및 수정 내역

- [x] CustomSlider 생성

### 슬라이더 오류

- 값을 확인해보니 `0.92`부근에서 모두 채워지고 `0.06`부분에서 모두 사라지는 문제가 있었습니다.
- 모두 채워지면서 사각형모양으로 채워지는 문제도 있었습니다.

<image width="250" src="https://github.com/user-attachments/assets/553ad2fe-b700-4984-946e-73bca77f9e35">

### 해결 과정

- 단순히 높이를 높여줌으로써 나타나는 UI 문제였습니다.
- 뭘 해봐도 잘 안되더라구요... 아래는 GPT의 의견...입니다.

<img width="600" src="https://github.com/user-attachments/assets/31fd1cc7-467e-4c58-99fb-0f4ce406fd86" />

- 결국 고심끝에 Slider는 유지하되 기본트랙을 숨기고 뒤에 트랙을 커스텀하는 방식을 택했습니다.

```swift
    private func setupUI() {
        /// 기본 track 숨김
        setMinimumTrackImage(UIImage(), for: .normal)
        setMaximumTrackImage(UIImage(), for: .normal)
        
        trackLayer.backgroundColor = UIColor.systemGray5.cgColor
        trackLayer.cornerRadius = .responsiveHeight(20) / 2
        layer.addSublayer(trackLayer)
        
        fillLayer.backgroundColor = UIColor.asBlue.cgColor
        fillLayer.cornerRadius = .responsiveHeight(20) / 2
        layer.addSublayer(fillLayer)
        
        addTarget(self, action: #selector(valueChanged), for: .valueChanged)
    }
```

## 리뷰 노트

- 다른 좋은 방법 아시면 의견 부탁드립니다.

## 스크린샷

- 스무스하게 잘 됩니다.

<image width="250" src="https://github.com/user-attachments/assets/858f3710-ad93-4ab3-b3e8-ece0b5154f37">


