### PR TITLE
[fix] 로비화면 복귀 시 로비 BGM 재생 

### DIFF
--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GameNavigationController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GameNavigationController.swift
@@ -191,8 +191,12 @@ final class GameNavigationController: @unchecked Sendable {
             }
         }
         
-        if viewType != .lobby{
+        if viewType != .lobby {
             BgmAudioHelper.shared.changeState(to: .ingame)
+        }
+        
+        if viewType == .lobby {
+            BgmAudioHelper.shared.changeState(to: .lobby)
         }
     }
 


### PR DESCRIPTION
## 필수 리뷰어

- @moral-life 

## 관련 이슈

- #134 

## 완료 및 수정 내역

 - [x] BGM 재생 변경

### 해결

- 민망하네요... 해당조건 넣어주니 해결되었습니다.

```swift
        if viewType != .lobby {
            BgmAudioHelper.shared.changeState(to: .ingame)
        }
        
        if viewType == .lobby {
            BgmAudioHelper.shared.changeState(to: .lobby)
        }
```

## 리뷰 노트

- 없습니다.
