### PR TITLE
[fix] 결과화면 노래 재생 오류 해결

### DIFF
--- a/alsongDalsong/ASEntity/ASEntity/GameState.swift
+++ b/alsongDalsong/ASEntity/ASEntity/GameState.swift
@@ -1,4 +1,4 @@
-public struct GameState {
+public struct GameState: Equatable {
     public let mode: Mode?
     public let recordOrder: UInt8?
     public let status: Status?

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/GameStateRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/GameStateRepository.swift
@@ -16,6 +16,7 @@ final class GameStateRepository: GameStateRepositoryProtocol {
                 guard let mode, let round, let players = self.mainRepository.players.value else { return nil }
                 return ASEntity.GameState(mode: mode, recordOrder: recordOrder, status: status, round: round, players: players)
             }
+            .removeDuplicates()
             .eraseToAnyPublisher()
     }
     

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/GameAudioHelper.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/GameAudioHelper.swift
@@ -144,6 +144,7 @@ extension GameAudioHelper {
         playType: PlayType = .full
     ) {
         Task {
+            guard await checkRecorderState() else { return }
             engineStateSubject.send(false)
             
             if playerEngine.playState == .play {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GameNavigationController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GameNavigationController.swift
@@ -173,7 +173,10 @@ final class GameNavigationController: @unchecked Sendable {
     }
 
     private func updateViewControllers(state: GameState) {
-        let viewType = state.resolveViewType()
+        guard let viewType = state.resolveViewType() else {
+            return
+        }
+        
         switch viewType {
         case .submitMusic: navigateToSelectMusic()
         case .humming: navigateToHumming()
@@ -184,7 +187,7 @@ final class GameNavigationController: @unchecked Sendable {
         default: break
         }
         
-        if viewType != .lobby{
+        if viewType != .lobby {
             Task {
                 BgmAudioHelper.shared.changeState(to: .ingame)
             }
@@ -219,7 +222,6 @@ final class GameNavigationController: @unchecked Sendable {
         let vc = LobbyViewController(lobbyViewModel: vm)
         setupNavigationBar(for: vc)
         navigationController.pushViewController(vc, animated: true)
-        BgmAudioHelper.shared.changeState(to: .lobby)
     }
 
     private func navigateToSelectMusic() {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GameNavigationController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GameNavigationController.swift
@@ -184,15 +184,10 @@ final class GameNavigationController: @unchecked Sendable {
         default: break
         }
         
-        if viewType != .result {
+        if viewType != .lobby{
             Task {
-                GameAudioHelper.shared.stopEngine()
-                await GameAudioHelper.shared.stopPlaying()
+                BgmAudioHelper.shared.changeState(to: .ingame)
             }
-        }
-        
-        if viewType != .lobby {
-            BgmAudioHelper.shared.changeState(to: .ingame)
         }
         
         if viewType == .lobby {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewController.swift
@@ -27,6 +27,12 @@ final class HummingViewController: UIViewController {
         setAction()
         bindToComponents()
     }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        largeAudioPlayerView.unbind()
+        viewModel.cancelSubscriptions()
+    }
 
     private func bindToComponents() {
         submissionStatus.bind(to: viewModel.$submissionStatus)
@@ -115,6 +121,7 @@ final class HummingViewController: UIViewController {
     }
 
     private func submitHumming() async throws {
+        viewModel.stopMusic()
         progressBar.cancelCompletion()
         try await viewModel.submitHumming()
         submitButton.setConfiguration(.submitted)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewModel.swift
@@ -114,4 +114,16 @@ final class HummingViewModel: @unchecked Sendable {
             }
             .store(in: &cancellables)
     }
+    
+    func stopMusic() {
+        Task {
+            await GameAudioHelper.shared.stopPlaying()
+            GameAudioHelper.shared.stopEngine()
+        }
+    }
+    
+    func cancelSubscriptions() {
+        cancellables.forEach { $0.cancel() }
+        cancellables.removeAll()
+    }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Player/AudioPlayerViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Player/AudioPlayerViewModel.swift
@@ -74,17 +74,18 @@ final class AudioPlayerViewModel: @unchecked Sendable {
         
         GameAudioHelper.shared.playerEnginePrgressPublisher
             .receive(on: DispatchQueue.main)
-            .sink { self.progress = $0 }
+            .sink { [weak self] in self?.progress = $0 }
             .store(in: &cancellables)
 
         GameAudioHelper.shared.normalizedFrequencyAmplitudesPublisher
             .receive(on: DispatchQueue.main)
-            .sink { self.normalizedFrequencyAmplitudes = $0 }
+            .sink { [weak self] in self?.normalizedFrequencyAmplitudes = $0 }
             .store(in: &cancellables)
 
         GameAudioHelper.shared.engineStatePublisher
             .receive(on: DispatchQueue.main)
-            .sink { state in
+            .sink { [weak self] state in
+                guard let self else { return }
                 Logger.debug("Engine State: \(state) | isPlaying: \(self.isPlaying)")
                 
                 if self.isPlaying && !state {
@@ -98,7 +99,8 @@ final class AudioPlayerViewModel: @unchecked Sendable {
             .store(in: &cancellables)
     }
 
-    private func unbindAudioHelper() {
+    func unbindAudioHelper() {
+        Logger.debug("Unbind AudioHelper in Function")
         progress = 0
         normalizedFrequencyAmplitudes = [0, 0, 0, 0, 0, 0]
         cancellables.forEach { $0.cancel() }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Player/LargeAudioPlayerView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Player/LargeAudioPlayerView.swift
@@ -79,22 +79,30 @@ final class LargeAudioPlayerView: UIView {
     private func bindViewModel() {
         viewModel?.$artworkData
             .receive(on: DispatchQueue.main)
-            .sink { self.configure(imageData: $0) }
+            .sink { [weak self] in
+                self?.configure(imageData: $0)
+            }
             .store(in: &cancellables)
 
         viewModel?.$progress
             .receive(on: DispatchQueue.main)
-            .sink { self.configure(progress: $0) }
+            .sink { [weak self] in
+                self?.configure(progress: $0)
+            }
             .store(in: &cancellables)
 
         viewModel?.$normalizedFrequencyAmplitudes
             .receive(on: DispatchQueue.main)
-            .sink { self.configure(normalizedFrequencyAmplitudes: $0) }
+            .sink { [weak self] in
+                self?.configure(normalizedFrequencyAmplitudes: $0)
+            }
             .store(in: &cancellables)
 
         viewModel?.$isPlaying
             .receive(on: DispatchQueue.main)
-            .sink { self.configure(with: $0) }
+            .sink { [weak self] in
+                self?.configure(with: $0)
+            }
             .store(in: &cancellables)
     }
 
@@ -203,6 +211,12 @@ final class LargeAudioPlayerView: UIView {
         controlButton.addAction(UIAction { [weak self] _ in
             self?.controlButtonDidTapped?()
         }, for: .touchUpInside)
+    }
+    
+    func unbind() {
+        cancellables.forEach { $0.cancel() }
+        cancellables.removeAll()
+        viewModel?.unbindAudioHelper()
     }
 }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Player/MediumAudioPlayerView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Player/MediumAudioPlayerView.swift
@@ -64,16 +64,6 @@ final class MediumAudioPlayerView: UIView {
             .store(in: &cancellables)
     }
 
-    func unbind() {
-        cancellables.forEach { $0.cancel() }
-        cancellables.removeAll()
-
-        viewModel?.$artworkData
-            .receive(on: DispatchQueue.main)
-            .sink { self.configure(imageData: $0) }
-            .store(in: &cancellables)
-    }
-
     private func bindWithPlayer() {
         controlButtonDidTapped = { [weak self] in
             self?.viewModel?.togglePlay()
@@ -202,6 +192,12 @@ final class MediumAudioPlayerView: UIView {
                 frequencyWaveView.centerYAnchor.constraint(equalTo: centerYAnchor)
             ])
         }
+    }
+    
+    func unbind() {
+        cancellables.forEach { $0.cancel() }
+        cancellables.removeAll()
+        viewModel?.unbindAudioHelper()
     }
 }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingViewController.swift
@@ -29,6 +29,8 @@ final class RehummingViewController: UIViewController {
     }
     
     override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        largeAudioPlayerView.unbind()
         viewModel.cancelSubscriptions()
     }
 
@@ -119,6 +121,7 @@ final class RehummingViewController: UIViewController {
     }
 
     private func submitHumming() async throws {
+        viewModel.stopMusic()
         progressBar.cancelCompletion()
         try await viewModel.submitHumming()
         submitButton.setConfiguration(.submitted)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingViewModel.swift
@@ -10,12 +10,12 @@ final class RehummingViewModel: @unchecked Sendable {
     @Published private(set) var music: Music?
     @Published private(set) var recordedData: Data?
     @Published private(set) var isRecording: Bool = false
-
+    
     private let gameStatusRepository: GameStatusRepositoryProtocol
     private let playersRepository: PlayersRepositoryProtocol
     private let recordsRepository: RecordsRepositoryProtocol
     private var cancellables: Set<AnyCancellable> = []
-
+    
     init(
         gameStatusRepository: GameStatusRepositoryProtocol,
         playersRepository: PlayersRepositoryProtocol,
@@ -26,7 +26,7 @@ final class RehummingViewModel: @unchecked Sendable {
         self.recordsRepository = recordsRepository
         bindGameStatus()
     }
-
+    
     func submitHumming() async throws {
         do {
             let dataToUpload: Data
@@ -51,13 +51,13 @@ final class RehummingViewModel: @unchecked Sendable {
             throw ASError.submitRehumming
         }
     }
-
+    
     func startRecording() {
         if !isRecording {
             isRecording = true
         }
     }
-
+    
     func updateRecordedData(with data: Data) {
         // TODO: - data가 empty일 때(녹음이 제대로 되지 않았을 때 사용자 오류처리 필요
         guard !data.isEmpty else {
@@ -67,14 +67,14 @@ final class RehummingViewModel: @unchecked Sendable {
         recordedData = data
         isRecording = false
     }
-
+    
     private func bindRecord(on recordOrder: UInt8) {
         recordsRepository.getHumming(on: recordOrder)
             .compactMap { $0 }
             .map { Music($0) }
             .assign(to: &$music)
     }
-
+    
     private func bindGameStatus() {
         gameStatusRepository.getDueTime()
             .receive(on: DispatchQueue.main)
@@ -90,11 +90,11 @@ final class RehummingViewModel: @unchecked Sendable {
             }
             .store(in: &cancellables)
     }
-
+    
     private func bindSubmissionStatus(with recordOrder: UInt8) {
         let playerPublisher = playersRepository.getPlayersCount()
         let recordsPublisher = recordsRepository.getRecordsCount(on: recordOrder)
-
+        
         playerPublisher.combineLatest(recordsPublisher)
             .sink { [weak self] playersCount, recordsCount in
                 let submitStatus = (submits: String(recordsCount), total: String(playersCount))
@@ -104,5 +104,14 @@ final class RehummingViewModel: @unchecked Sendable {
     }
     
     func cancelSubscriptions() {
+        cancellables.forEach { $0.cancel() }
         cancellables.removeAll()
-    }}
+    }
+    
+    func stopMusic() {
+        Task {
+            await GameAudioHelper.shared.stopPlaying()
+            GameAudioHelper.shared.stopEngine()
+        }
+    }
+}

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewController.swift
@@ -35,7 +35,7 @@ class HummingResultViewController: UIViewController {
 
     override func viewDidDisappear(_ animation: Bool) {
         super.viewDidDisappear(animation)
-        
+        answerView.unbind()
         viewModel?.cancelSubscriptions()
     }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewModel.swift
@@ -114,6 +114,7 @@ final class HummingResultViewModel: @unchecked Sendable {
     }
 
     func cancelSubscriptions() {
+        cancellables.forEach { $0.cancel() }
         cancellables.removeAll()
     }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewController.swift
@@ -26,6 +26,7 @@ final class SelectMusicViewController: UIViewController {
     }
     
     override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
         viewModel.cancelSubscriptions()
     }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
@@ -97,6 +97,7 @@ final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
     func stopMusic() {
         Task {
             await GameAudioHelper.shared.stopPlaying()
+            GameAudioHelper.shared.stopEngine()
         }
     }
     
@@ -199,6 +200,7 @@ final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
     }
     
     func cancelSubscriptions() {
+        cancellables.forEach { $0.cancel() }
         cancellables.removeAll()
     }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SelectAnswerButton.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SelectAnswerButton.swift
@@ -77,16 +77,16 @@ final class SelectAnswerButton: UIButton {
     private func bindViewModel() {
         viewModel?.$isPlaying
             .receive(on: DispatchQueue.main)
-            .sink { self.configure(with: $0) }
+            .sink { [weak self] in self?.configure(with: $0) }
             .store(in: &cancellables)
 
         viewModel?.$artworkData
             .receive(on: DispatchQueue.main)
-            .sink { self.configure(imageData: $0) }
+            .sink { [weak self] in self?.configure(imageData: $0) }
             .store(in: &cancellables)
 
         viewModel?.$normalizedFrequencyAmplitudes
-            .sink { self.configure(normalizedFrequencyAmplitudes: $0) }
+            .sink { [weak self] in self?.configure(normalizedFrequencyAmplitudes: $0) }
             .store(in: &cancellables)
     }
 
@@ -235,6 +235,12 @@ final class SelectAnswerButton: UIButton {
     func configure(with isPlaying: Bool) {
         let buttonState: AudioControlButtonState = isPlaying ? .stop : .play
         controlButton.configuration?.image = buttonState.symbol
+    }
+    
+    func unbind() {
+        cancellables.forEach { $0.cancel() }
+        cancellables.removeAll()
+        viewModel?.unbindAudioHelper()
     }
 }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewController.swift
@@ -30,6 +30,8 @@ final class SubmitAnswerViewController: UIViewController {
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
+        selectAnswerButton.unbind()
+        largeAudioPlayerView.unbind()
         viewModel.cancelSubscriptions()
     }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
@@ -117,6 +117,7 @@ final class SubmitAnswerViewModel: ObservableObject, @unchecked Sendable {
     func stopMusic() {
         Task {
             await GameAudioHelper.shared.stopPlaying()
+            GameAudioHelper.shared.stopEngine()
         }
     }
 
@@ -214,6 +215,7 @@ final class SubmitAnswerViewModel: ObservableObject, @unchecked Sendable {
     }
 
     func cancelSubscriptions() {
+        cancellables.forEach { $0.cancel() }
         cancellables.removeAll()
     }
 


### PR DESCRIPTION
## 필수 리뷰어

@hyunjuntyler 

## 관련 이슈

- #131 

## 완료 및 수정 내역

 - [ ]

## 테스트 방법 (선택)

## 리뷰 노트
* 원인은 제출버튼에 stopMusic()을 호출해주고있었습니다.
  * 해당 메서드는 GameAudioHelper.shared.stopPlaying() 메서드를 비동기로 호출 하고있는 메서드입니다.
  * Engine이 생기고 나서 부터 제출버튼을 눌러도 Engine은 멈추지 않고 재생이 되고 있었고, Game Navigation Controller 에서 뷰 전환 시 BGM을 재생해야 하기 때문에 `stopPlaying()`과 `stopEngine()` 을 호출하고 있어, Result에서 Publish 값들이 꼬인 것 같습니다. 
  
  * 해결 방법으로 GameNavigationController 에서 노래 정지 부분을 삭제하고, SubmitMusic, Answer, Humming, Rehumming ViewController 에서 제출 버튼 을 누를 때 노래 정지되도록 수정하였습니다.
  
  * 추가적으로 Navigaiton Push로 뷰를 이동하다 보니,
   Audio Player Component들의 deinit이 호출되지 않아, Binding을 계속 유지하고 있는 문제가 있어, ViewController에서 따로 unbind() 를 호출하도록 수정하였습니다.


## 스크린샷 (선택)

![화면 기록 2025-05-22 오후 5 04 36](https://github.com/user-attachments/assets/c34fa74c-4d8c-4f52-99eb-a91dde38f381)
