### PR TITLE
[fix] BGM 슬라이더 조절하고 화면 넘어갔을 때 변경사항 적용 안되던 문제 해결

### DIFF
--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/BgmAudioHelper.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/BgmAudioHelper.swift
@@ -104,7 +104,7 @@ extension BgmAudioHelper {
     func playBgm() {
         Task {
             print(#function)
-            await startPlaying(bgmDatas[bgmState], option: .loop, volume: volume)
+            await startPlaying(bgmDatas[bgmState], option: .loop)
         }
     }
 
@@ -130,7 +130,6 @@ extension BgmAudioHelper {
     func startPlaying(_ file: Data?,
                       sourceType type: FileSource = .imported(.large),
                       option: PlayType = .full,
-                      volume: Float = 1.0,
                       needsWaveUpdate: Bool = false) async
     {
         guard await checkPlayerState() else { return }
@@ -149,10 +148,10 @@ extension BgmAudioHelper {
             updatePlayIndex()
         }
 
-        await play(file: file, option: option, volume: volume)
+        await play(file: file, option: option)
     }
 
-    private func play(file: Data, option: PlayType, volume: Float) async {
+    private func play(file: Data, option: PlayType) async {
         switch option {
         case .full:
             do {
@@ -171,6 +170,7 @@ extension BgmAudioHelper {
         case .loop:
             do {
                 try await player?.startPlaying(data: file, fade: true, isLoop: true)
+                await player?.setVolume(volume)
             } catch {
                 ErrorHandler.handle(error)
             }


### PR DESCRIPTION
## 필수 리뷰어
- nil
## 관련 이슈

- #137 

## 완료 및 수정 내역

 - [x] 슬라이더값 변경 후 화면 넘어가도 비지엠 크기 조정된 값으로 적용되도록 변경

## 테스트 방법 (선택)

## 리뷰 노트

원인은 놀랍게도 startPlaying 할 때 마다 player 인스턴스를 생성하고 다 틀면 nil로 만드는 형태였기 때문입니다.
그래서 화면을 전환하고 새로 playBgm을 하더라도 volume이 적용된 것이 아닌 새로 만들어진 플레이어에 default 볼륨 값이 들어가고있었습니다. 그리하여 플레이어를 만들고 나서 소리 크기를 적용시키도록 변경 하였습니다. 
## 스크린샷 (선택)
