### PR TITLE
[fix] 무음모드 소리 안나오던거 수정, Publisher 및 BgmAudioHelper에 불필요한 코드 삭제

### DIFF
--- a/alsongDalsong/ASAudioKit/ASAudioKit/ASAudioRecorder/ASAudioRecorder.swift
+++ b/alsongDalsong/ASAudioKit/ASAudioKit/ASAudioRecorder/ASAudioRecorder.swift
@@ -8,7 +8,6 @@ public actor ASAudioRecorder {
     /// 녹음 후 저장될 파일의 위치를 지정하여 녹음합니다.
     public func startRecording(url: URL) throws {
         do {
-            try configureAudioSession()
             let settings = [
                 AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
                 AVSampleRateKey: 12000,
@@ -23,19 +22,6 @@ public actor ASAudioRecorder {
             // TODO: AVAudioRecorder 객체 생성 실패 시에 대한 처리
             ErrorHandler.handle(error)
             throw ASAudioError.startRecording
-        }
-    }
-
-    /// 오디오 세션을 설정합니다.
-    private func configureAudioSession() throws {
-        do {
-            let session = AVAudioSession.sharedInstance()
-            try session.setCategory(.playAndRecord, mode: .default, options: [.defaultToSpeaker])
-            try session.setActive(true, options: .notifyOthersOnDeactivation)
-        } catch {
-            // TODO: 세션 설정 실패에 따른 처리
-            ErrorHandler.handle(error)
-            throw ASAudioError.configureAudioSession
         }
     }
 

--- a/alsongDalsong/ASAudioKit/ASAudioKit/ASAudioRecorder/ASAudioRecorder.swift
+++ b/alsongDalsong/ASAudioKit/ASAudioKit/ASAudioRecorder/ASAudioRecorder.swift
@@ -5,6 +5,7 @@ public actor ASAudioRecorder {
     private var audioRecorder: AVAudioRecorder?
 
     public init() {}
+
     /// 녹음 후 저장될 파일의 위치를 지정하여 녹음합니다.
     public func startRecording(url: URL) throws {
         do {

--- a/alsongDalsong/ASAudioKit/ASAudioKitTests/ASAudioRecorderTests.swift
+++ b/alsongDalsong/ASAudioKit/ASAudioKitTests/ASAudioRecorderTests.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Foundation
 import Testing
 
@@ -6,12 +7,15 @@ struct ASAudioRecorderTests {
 
     init() async throws {
         recorder = ASAudioRecorder()
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(.playAndRecord, mode: .default, options: [.defaultToSpeaker])
+        try session.setActive(true, options: .notifyOthersOnDeactivation)
     }
 
     @Test("녹음 시작 테스트") func startRecording() async throws {
         let url = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
             .appendingPathComponent("녹음성공테스트")
-        
+
         try await recorder.startRecording(url: url)
         let isRecording = await recorder.isRecording()
         #expect(isRecording)
@@ -20,7 +24,7 @@ struct ASAudioRecorderTests {
     @Test("녹음 완료 후 저장 테스트") func stopRecording() async throws {
         let url = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
             .appendingPathComponent("녹음저장성공테스트")
-        
+
         try await recorder.startRecording(url: url)
         await recorder.stopRecording()
         #expect(FileManager.default.fileExists(atPath: url.path))

--- a/alsongDalsong/ASAudioKit/ASAudioPlayerEngine.swift
+++ b/alsongDalsong/ASAudioKit/ASAudioPlayerEngine.swift
@@ -52,10 +52,6 @@ public class ASAudioPlayerEngine: @unchecked Sendable {
     public func bind(data: Data, sampleCount: Int = 6) {
         self.sampleCount = sampleCount
 
-        let session = AVAudioSession.sharedInstance()
-        try? session.setCategory(.playback, mode: .default, options: [])
-        try? session.setActive(true, options: .notifyOthersOnDeactivation)
-        
         let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".m4a")
         try? data.write(to: tempURL)
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/BgmAudioHelper.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/BgmAudioHelper.swift
@@ -1,5 +1,6 @@
 import ASAudioKit
 import ASLogKit
+import AVFoundation
 import Combine
 import Foundation
 
@@ -7,7 +8,11 @@ final class BgmAudioHelper: @unchecked Sendable {
     // MARK: - Singleton
 
     static let shared = BgmAudioHelper()
-    private init() {}
+    private init() {
+        do {
+            try configureAudioSession()
+        } catch {}
+    }
 
     // MARK: - Private properties
 
@@ -95,6 +100,17 @@ final class BgmAudioHelper: @unchecked Sendable {
         Logger.debug(#function)
         cancellable?.cancel()
         cancellable = nil
+    }
+
+    private func configureAudioSession() throws {
+        do {
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.playAndRecord, mode: .default, options: [.defaultToSpeaker])
+            try session.setActive(true, options: .notifyOthersOnDeactivation)
+        } catch {
+            // TODO: 세션 설정 실패에 따른 처리
+            ErrorHandler.handle(error)
+        }
     }
 }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/BgmAudioHelper.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/BgmAudioHelper.swift
@@ -83,7 +83,7 @@ extension BgmAudioHelper {
     func playBgm() {
         Task {
             print(#function)
-            await startPlaying(bgmDatas[bgmState], volume: volume)
+            await startPlaying(bgmDatas[bgmState])
         }
     }
 
@@ -105,11 +105,7 @@ extension BgmAudioHelper {
     /// - Parameters:
     ///   - file: 재생할 오디오 데이터
     ///   - source: 녹음 파일/url에서 가져온 파일
-    func startPlaying(_ file: Data?,
-                      sourceType type: FileSource = .imported(.large),
-                      volume: Float = 1.0,
-                      needsWaveUpdate: Bool = false) async
-    {
+    func startPlaying(_ file: Data?, sourceType type: FileSource = .imported(.large)) async {
         guard let file else { return }
 
         sourceType(type)
@@ -118,12 +114,13 @@ extension BgmAudioHelper {
         await player?.setOnPlaybackFinished { [weak self] in
             await self?.stopPlaying()
         }
-        await play(file: file, volume: volume)
+        await play(file: file)
     }
 
-    private func play(file: Data, volume: Float) async {
+    private func play(file: Data) async {
         do {
             try await player?.startPlaying(data: file, fade: true, isLoop: true)
+            await player?.setVolume(volume)
         } catch {
             ErrorHandler.handle(error)
         }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/BgmAudioHelper.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/BgmAudioHelper.swift
@@ -47,43 +47,6 @@ final class BgmAudioHelper: @unchecked Sendable {
 
     private let queue = DispatchQueue(label: "alsongDalsong.AudioHelper")
 
-    // MARK: - Publishers
-
-    private let amplitudeSubject = PassthroughSubject<Float, Never>()
-    private let playerStateSubject = PassthroughSubject<(FileSource, Bool), Never>()
-    private let waveformUpdateSubject = PassthroughSubject<Int, Never>()
-    private let recorderStateSubject = PassthroughSubject<Bool, Never>()
-    private let recorderDataSubject = PassthroughSubject<Data, Never>()
-    private let normalizedFrequencyAmplitudes = PassthroughSubject<[Float], Never>()
-    private let playerEnginePrgress = PassthroughSubject<Double, Never>()
-    var amplitudePublisher: AnyPublisher<Float, Never> {
-        amplitudeSubject.eraseToAnyPublisher()
-    }
-
-    var playerStatePublisher: AnyPublisher<(FileSource, Bool), Never> {
-        playerStateSubject.eraseToAnyPublisher()
-    }
-
-    var waveformUpdatePublisher: AnyPublisher<Int, Never> {
-        waveformUpdateSubject.eraseToAnyPublisher()
-    }
-
-    var recorderStatePublisher: AnyPublisher<Bool, Never> {
-        recorderStateSubject.eraseToAnyPublisher()
-    }
-
-    var recorderDataPublisher: AnyPublisher<Data, Never> {
-        recorderDataSubject.eraseToAnyPublisher()
-    }
-
-    var normalizedFrequencyAmplitudesPublisher: AnyPublisher<[Float], Never> {
-        normalizedFrequencyAmplitudes.eraseToAnyPublisher()
-    }
-
-    var playerEnginePrgressPublisher: AnyPublisher<Double, Never> {
-        playerEnginePrgress.eraseToAnyPublisher()
-    }
-
     var isPlaying: Bool {
         get async {
             guard let player else { return false }
@@ -120,7 +83,7 @@ extension BgmAudioHelper {
     func playBgm() {
         Task {
             print(#function)
-            await startPlaying(bgmDatas[bgmState], option: .loop, volume: volume)
+            await startPlaying(bgmDatas[bgmState], volume: volume)
         }
     }
 
@@ -142,14 +105,11 @@ extension BgmAudioHelper {
     /// - Parameters:
     ///   - file: 재생할 오디오 데이터
     ///   - source: 녹음 파일/url에서 가져온 파일
-    ///   - playType: 전체 또는 부분 재생
     func startPlaying(_ file: Data?,
                       sourceType type: FileSource = .imported(.large),
-                      option: PlayType = .full,
                       volume: Float = 1.0,
                       needsWaveUpdate: Bool = false) async
     {
-        guard await checkPlayerState() else { return }
         guard let file else { return }
 
         sourceType(type)
@@ -159,38 +119,14 @@ extension BgmAudioHelper {
             await self?.stopPlaying()
         }
 
-        playerStateSubject.send((source, true))
-
-        if needsWaveUpdate {
-            updatePlayIndex()
-        }
-
-        await play(file: file, option: option, volume: volume)
+        await play(file: file, volume: volume)
     }
 
-    private func play(file: Data, option: PlayType, volume: Float) async {
-        switch option {
-        case .full:
-            do {
-                try await player?.startPlaying(data: file)
-            } catch {
-                ErrorHandler.handle(error)
-            }
-        case let .partial(time):
-            do {
-                try await player?.startPlaying(data: file)
-                try await Task.sleep(for: .seconds(time))
-                await stopPlaying()
-            } catch {
-                ErrorHandler.handle(error)
-            }
-        case .loop:
-            do {
-                try await player?.startPlaying(data: file, fade: true, isLoop: true)
-            } catch {
-                ErrorHandler.handle(error)
-            }
-        @unknown default: break
+    private func play(file: Data, volume: Float) async {
+        do {
+            try await player?.startPlaying(data: file, fade: true, isLoop: true)
+        } catch {
+            ErrorHandler.handle(error)
         }
     }
 
@@ -201,8 +137,6 @@ extension BgmAudioHelper {
 
         removePlayer()
         removeTimer()
-
-        playerStateSubject.send((source, false))
     }
 
     func pause() async {
@@ -217,28 +151,8 @@ extension BgmAudioHelper {
         }
     }
 
-    private func updatePlayIndex() {
-        cancellable = Timer.publish(every: 0.25, on: .main, in: .common)
-            .autoconnect()
-            .scan(0) { count, _ in
-                count + 1
-            }
-            .sink { [weak self] value in
-                self?.waveformUpdateSubject.send(value - 1)
-            }
-    }
-
     private func makePlayer() {
         player = ASAudioPlayer()
-    }
-
-    private func checkPlayerState() async -> Bool {
-        if await isPlaying {
-            await player?.stopPlaying()
-            removePlayer()
-            playerStateSubject.send((source, false))
-        }
-        return true
     }
 }
 
@@ -253,12 +167,6 @@ extension BgmAudioHelper {
     @discardableResult
     private func sourceType(_ type: FileSource) -> Self {
         source = type
-        return self
-    }
-
-    @discardableResult
-    func isConcurrent(_ isTrue: Bool) -> Self {
-        isConcurrent = isTrue
         return self
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/GameAudioHelper.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/GameAudioHelper.swift
@@ -1,6 +1,5 @@
 import ASAudioKit
 import ASLogKit
-import AVFoundation
 import Combine
 import Foundation
 
@@ -8,11 +7,7 @@ final class GameAudioHelper: @unchecked Sendable {
     // MARK: - Singleton
 
     static let shared = GameAudioHelper()
-    private init() {
-        do {
-            try configureAudioSession()
-        } catch {}
-    }
+    private init() {}
 
     // MARK: - Private properties
 
@@ -75,17 +70,6 @@ final class GameAudioHelper: @unchecked Sendable {
         playerEnginePrgress.eraseToAnyPublisher()
     }
 
-    private func configureAudioSession() throws {
-        do {
-            let session = AVAudioSession.sharedInstance()
-            try session.setCategory(.playAndRecord, mode: .default, options: [.defaultToSpeaker])
-            try session.setActive(true, options: .notifyOthersOnDeactivation)
-        } catch {
-            // TODO: 세션 설정 실패에 따른 처리
-            ErrorHandler.handle(error)
-        }
-    }
-
     var isRecording: Bool {
         get async {
             guard let recorder else { return false }
@@ -145,7 +129,7 @@ extension GameAudioHelper {
     ) {
         Task {
             engineStateSubject.send(false)
-            
+
             if playerEngine.playState == .play {
                 stopEngine()
             }
@@ -153,7 +137,7 @@ extension GameAudioHelper {
             if await player?.isPlaying() ?? false {
                 await stopPlaying()
             }
-            
+
             if await BgmAudioHelper.shared.isPlaying {
                 await BgmAudioHelper.shared.stopPlaying()
             }


### PR DESCRIPTION
## 필수 리뷰어

## 관련 이슈

- #139 

## 완료 및 수정 내역

 - [x] AVAudioSession 설정하는 것은 앱 내에서 딱 한 번 (BgmAudioHelper init 하는 부분에서 하게 함) 

## 테스트 방법 (선택)

## 리뷰 노트

기존에는 AVAudioSession 설정해주는 부분을 GameAudioHelper에서 실행하게 하였습니다. 

무음모드에서도 소리가 나게 하려면 Session 설정하는 부분이 선행이 되고, 그 다음에 BGM이 틀어져야 합니다. 
(`.playback` 혹은 `.playAndRecord` 설정해야함) 

허나 싱글톤들(GameHelper/BgmHelper) init을 하는 시점을 디버그를 해보았는데, BgmAudioHelper 가 먼저 초기화가 되고 온보딩 내에서는 GameAudioHelper가 초기화 되지 않습니다(싱글톤 객체 자체가 생성 안됨). 

로비화면으로 넘어가게 되면 GameNaviController 쪽에 있는 update하는 부분에서 최초로 GameAudioHelper를 사용하게 되고 그제서야 GameAudioHelper를 초기화 하게 되고, 그 안에 있던 AVAudioSession configure 하는 것이 실행이 되고 그제서야 무음모드에서도 노래가 나오게 됐던 것이었습니다. 그리하여 해당 부분을 그냥 BgmHelper쪽으로 옮겨서 해결하였습니다. 
이를 통해 싱글톤은 앱 시작과 동시에 만들어지는 것이 아니라 실제로 사용할 때가 돼서야 만들어진 다는것을 알게 됐습니다. 

그리고 퍼블리셔를 젠가하듯이 과감하게 빼 보았는데, 아직까지는 문제점 없습니다. 전에 말씀하신 결과 선택화면에서 노래를 재생 시킨 뒤에 넘어가지만 않는다면 문제 없이 동작 하는 것 같습니다. 
BgmHelper에 불필요한 코드를 삭제 했습니다. 사실 더 삭제할 수 있을 것도 같은데 최대한 안전한 선 내에서 줄여봤습니다. 
허나 state나 index 관련 부분도 삭제했고 이부분이 마음에 쓰여서 결과화면 고치는 쪽에서(@Sonny-Kor) 필히 알고 계셨으면 좋겠습니다. 

## 스크린샷 (선택)
