### PR TITLE
[bug] 리소스 다운 무한 로딩 이슈

### DIFF
--- a/alsongDalsong/ASNetworkKit/ASNetworkKit/Firebase/ASFirebaseStorage.swift
+++ b/alsongDalsong/ASNetworkKit/ASNetworkKit/Firebase/ASFirebaseStorage.swift
@@ -33,7 +33,11 @@ final class ASFirebaseStorage: ASFirebaseStorageProtocol {
                 guard let lobbyURL = lobbyDict[key] else { return nil }
                 return AvatarPair(onboarding: onboardingURL, lobby: lobbyURL)
             }
-
+            
+            if pairs.isEmpty {
+                throw ASNetworkError.getAvatarUrls
+            }
+            
             return pairs
             
         } catch {
@@ -70,7 +74,7 @@ final class ASFirebaseStorage: ASFirebaseStorageProtocol {
     
     private func extractFileNumber(from url: URL) -> Int? {
         let filename = url.lastPathComponent
-        let baseFilename = filename.split(separator: "?").first ?? ""
+        let baseFilename = filename.split(separator: "/").last ?? ""
         let numberString = baseFilename.split(separator: ".").first ?? ""
         return Int(numberString)
     }

--- a/alsongDalsong/alsongDalsong/alsongDalsong.xcodeproj/project.pbxproj
+++ b/alsongDalsong/alsongDalsong/alsongDalsong.xcodeproj/project.pbxproj
@@ -476,6 +476,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = "알쏭달쏭";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.music-games";
 				INFOPLIST_KEY_NSAppleMusicUsageDescription = "알쏭달쏭은 Apple Music을 이용하여 음악을 찾는 것을 돕습니다";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "허밍해보세요!";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIStatusBarHidden = YES;
@@ -514,6 +515,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = "알쏭달쏭";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.music-games";
 				INFOPLIST_KEY_NSAppleMusicUsageDescription = "알쏭달쏭은 Apple Music을 이용하여 음악을 찾는 것을 돕습니다";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "허밍해보세요!";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIStatusBarHidden = YES;

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Resources/Info.plist
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Resources/Info.plist
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSAppleMusicUsageDescription</key>
-	<string>알쏭달쏭은 Apple Music을 이용하여 음악을 찾는 것을 돕습니다</string>
-	<key>NSMicrophoneUsageDescription</key>
-	<string>허밍해보세요!</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -44,5 +40,7 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UIDesignRequiresCompatibility</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## 필수 리뷰어

- nil

## 관련 이슈

- #148 

## 완료 및 수정 내역

 - [x] 리소스 다운 무한 로딩 이슈
 - [x] iOS26에서 네비게이션 바가 이상하게 보이는 문제 해결  

## 테스트 방법 (선택)

- [x] 1.0.0v 에서 발견됌

## 리뷰 노트

```swift
"https://firebasestorage.googleapis.com:443/v0/b/alsongdalsong-boostcamp.firebasestorage.app/o/avatar%2F7.png?alt=media&token=..."
/ *
리소스 URL 이 기존에는 lastPathComponent 했을 때 제대로 동작을 하다가
"avatars%2F7.png?alt=media&token=..."
형태로 나왔었던 것이 이제는 쿼리 형식이 다 빠지고, avatar/7 이런 형태로 나오네용 ??

그래서 로비와 온보딩에 사용되는 이미지 파일명 짝이 안맞는 이슈가 생겨서 무한로딩이 생겼습니다.
*/
```
